### PR TITLE
Add pvd files from paraview data

### DIFF
--- a/Data/PVD/paraview/LICENSE_PARAVIEW
+++ b/Data/PVD/paraview/LICENSE_PARAVIEW
@@ -1,0 +1,31 @@
+Copyright (c) 2005-2008 Sandia Corporation, Kitware Inc.
+Sandia National Laboratories, New Mexico PO Box 5800 Albuquerque, NM 87185
+Kitware Inc., 28 Corporate Drive, Clifton Park, NY 12065, USA
+
+Under the terms of Contract DE-AC04-94AL85000, there is a non-exclusive license
+for use of this work by or on behalf of the U.S. Government.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list
+  of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+* Neither the name of Kitware nor the names of any contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Data/PVD/paraview/dualSphereAnimation.clone.pvd
+++ b/Data/PVD/paraview/dualSphereAnimation.clone.pvd
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<VTKFile type="Collection" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <Collection>
+    <DataSet timestep="0" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0000.vtp"/>
+    <DataSet timestep="0" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0000.vtp"/>
+    <DataSet timestep="1" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0001.vtp"/>
+    <DataSet timestep="1" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0001.vtp"/>
+    <DataSet timestep="2" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0002.vtp"/>
+    <DataSet timestep="2" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0002.vtp"/>
+    <DataSet timestep="3" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0003.vtp"/>
+    <DataSet timestep="3" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0003.vtp"/>
+    <DataSet timestep="4" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0004.vtp"/>
+    <DataSet timestep="4" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0004.vtp"/>
+    <DataSet timestep="5" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0005.vtp"/>
+    <DataSet timestep="5" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0005.vtp"/>
+    <DataSet timestep="6" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0006.vtp"/>
+    <DataSet timestep="6" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0006.vtp"/>
+    <DataSet timestep="7" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0007.vtp"/>
+    <DataSet timestep="7" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0007.vtp"/>
+    <DataSet timestep="8" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0008.vtp"/>
+    <DataSet timestep="8" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0008.vtp"/>
+    <DataSet timestep="9" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0009.vtp"/>
+    <DataSet timestep="9" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0009.vtp"/>
+    <DataSet timestep="10" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0010.vtp"/>
+    <DataSet timestep="10" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0010.vtp"/>
+  </Collection>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation.pvd
+++ b/Data/PVD/paraview/dualSphereAnimation.pvd
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<VTKFile type="Collection" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <Collection>
+    <DataSet timestep="0" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0000.vtp"/>
+    <DataSet timestep="0" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0000.vtp"/>
+    <DataSet timestep="1" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0001.vtp"/>
+    <DataSet timestep="1" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0001.vtp"/>
+    <DataSet timestep="2" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0002.vtp"/>
+    <DataSet timestep="2" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0002.vtp"/>
+    <DataSet timestep="3" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0003.vtp"/>
+    <DataSet timestep="3" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0003.vtp"/>
+    <DataSet timestep="4" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0004.vtp"/>
+    <DataSet timestep="4" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0004.vtp"/>
+    <DataSet timestep="5" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0005.vtp"/>
+    <DataSet timestep="5" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0005.vtp"/>
+    <DataSet timestep="6" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0006.vtp"/>
+    <DataSet timestep="6" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0006.vtp"/>
+    <DataSet timestep="7" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0007.vtp"/>
+    <DataSet timestep="7" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0007.vtp"/>
+    <DataSet timestep="8" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0008.vtp"/>
+    <DataSet timestep="8" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0008.vtp"/>
+    <DataSet timestep="9" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0009.vtp"/>
+    <DataSet timestep="9" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0009.vtp"/>
+    <DataSet timestep="10" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0010.vtp"/>
+    <DataSet timestep="10" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0010.vtp"/>
+  </Collection>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation.vtp.series
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation.vtp.series
@@ -1,0 +1,16 @@
+{
+  "file-series-version" : "1.0",
+  "files" : [
+    { "name" : "dualSphereAnimation_P00T0000.vtp", "time" : 0 },
+    { "name" : "dualSphereAnimation_P00T0001.vtp", "time" : 3 },
+    { "name" : "dualSphereAnimation_P00T0002.vtp", "time" : 6 },
+    { "name" : "dualSphereAnimation_P00T0003.vtp", "time" : 9 },
+    { "name" : "dualSphereAnimation_P00T0004.vtp", "time" : 11.0 },
+    { "name" : "dualSphereAnimation_P00T0005.vtp", "time" : 12.0 },
+    { "name" : "dualSphereAnimation_P00T0006.vtp", "time" : 13.0 },
+    { "name" : "dualSphereAnimation_P00T0007.vtp", "time" : 16.0 },
+    { "name" : "dualSphereAnimation_P00T0008.vtp", "time" : 20.0 },
+    { "name" : "dualSphereAnimation_P00T0009.vtp", "time" : 21.0 },
+    { "name" : "dualSphereAnimation_P00T0010.vtp", "time" : 25.0 }
+  ]
+}

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0000.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0000.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="50"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="444"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1084"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1520"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1536"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1552"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1568"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1584"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1600"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1616"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2044"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAABYAgAAOQEAAA==eJxFkbFKA1EQRRcsXAsbMSooBESCcQ0sRLDb7SRfYRPIF9hIGhstLMV2LYT8gK+we1OmM9F6EUEMpEi+wTkv80hg4MLOnD17kyTxd1cm6ywbre+C9DcalEetXni2WTXLn+fbkO/rfhHzY933h7aTVk1J7HY2GkjWqIpzHTjTh+3yUwfO3jAPAydmOOwwcM70joGznL++4QRHxjsOJzh5eunwgBMzHK87OMFZ6C1OcNTFZ+ajLjI1n/1hLg3zidl8ZLL28W3zURe/nB8760dk/OSsH8nTd2f9hGz9iNcd68cv9BYOzI4OHH2P4ARH3y94wIkZTtyB0159i4czu77p4gTnJau7OME5udq6wANOzHAq3cEJzq/e4gSns+o8cL70uyfmc6B97JpPzHD4Pz/Mh15Pzecfk9/1IA==AQAAAACAAACABAAAzQEAAA==eJxNkztOAzEQhldKeHYgUARVLrAgDsBaBAEBskgJDRWvmgNQRqJA4g684QQpI+wiHVUuQQKBkCIgUfL/6zFM5W/X4/k8Y7vWOU62fprLS+enpoyxhm/y9k/zKfBu59iWJaYKTjFHXsPIOfIO5qvCXLchMSl41a91JYypz+nWMV8Rxj8bYvDPrvm1zmBMfU63ifmKMHOUJObrYt6MjdWTw+cVE/gIvFjYM2+5RnJVbCcL4B74BnxwdmJmB60kiqK6Zsa8Iuau2LaamXPE53SaOfKbrlFh7oHr6KZX8ww89NGluYsY+ujSnP/Pr10O9dngCsw9vOca2b7p0lwYtOy+d0WaGRMj5haunvA9mDmH4hpXDI+T2k3gQ99n18G+r+Eid6XnqM9N+95GmmOJefR9ztZKn53q8x/D7yaxDzlfNyHMtayBLubsg5EnQX2OddKlOZZ4usg9YeZnzcEVGH77jW+68opfsI513vrzzfgSPAUP66RLs4q3genN+bNzdGlGfclQXIHZ876/G471BmbP59DXfXFp/kRMLN4P4Qewysm+/jHvUd7XbuSe2/COcEZWztd0pee8v9PSW82xxMj5Zv1S78iqd5TxL7NC8VE=AQAAAACAAABYAgAANAEAAA==eJxFkb1KA0EURhcs3FqMCmojEswfBFNYOXY+heRFUiso2ATbTSCQPkwKK++WsTLROoWwuGChlY2d90zumIULX3HnzJlvk+T/u1jHJN+odh3hY1y6g+pzyJvZ0L0//IZ8vSzOY75bFk/7tpNmQ0nsbDkupVE5dE0dOIube/eqA2enNwkDJ2Y47DBw6nqOgfP9eeRxgpPP+h4nOO300eMBJ2Y4ojs4wfnSszjBUZfgBEddZGE+u72JVMwnZvOR+dpHauajLuo08taP5LOtqfUj7fRsav2EbP2I6I71o04jDwdmSweO3iM4wdH7BQ84McOJO3Bqq7cInLL7c4oTnEHjqoMTnOPL2w4ecGKGk+kOTnAKPYsTnNaq88B503fPzWdP+9g2n5jh8D9fzIdeT8znD4crGMU=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAALwEAAA==eJwt0QduwlAQAFHTTMdgOgFMaKGFcv/Lxas8pNWO/kizAqpJkrSS/0/sAY49wbFXOPYOxz7j2A8cu4qb5VTK6ZvgsQlemuDCBJ9M8N0Ef0xFO+7Uymnjtu8Rb/VyOrjDxVujnC7ucvGWltPDPS51p4/7XEsvw5nfrK03xEOuozfCI66rl+Oc67k1xmNuoDfFU/9PpjfDM26oN8dzbqS3wAsud2uJl9xE7wvHXnmL3hqvuZneBm+4ud4Wb7mFWwUuuJXeN4698xa9Pd5za70DPnAbvSM+clu3TvjE7fR+cOyzt+hd8IXb613xlTvo3fCNO7p1x3furPeLYz+8Re+Jn9xF74Vf3FXvjd/cza0P/nAPvRqOXfUWvTquc0+9Bm5wL70Up9zbrSZucn/DQBshAQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0001.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0001.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="648"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1552"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2192"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2208"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2224"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2240"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2256"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2272"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2288"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2724"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAA0wEAAA==eJxFz01I1EEcxvF1JVuFLl5SXBClFETQUlDU/wwIvi56KA0qkkBcXVEQD4qskhhGGIJQQlrbIfGllBQsCKoZD0keXEUEFZIQZQXNFLv4kkHPM/inOf0Oz/cD43DYr1M6/t964eO0uPu0S4SGvbJzL0GGl/4UFwPxsmG3RHqmo2X3erXgXYq7Z71aPcDGiY0rEK/n0d5Guz3s1clNi9aUc8046aEcUfMqX9I5ueQTDyebjWPfdNLON3Suon2Hlk7ofYnqPZg1Tt6nD6qj8rpxHgU21fH9KuPwPsJNJxebdmzobKHtQUsnygqq+ogU46zuZOvfaQPmXzf7vdp/QQs6N85vOtwcYkPHhbYOLZ3nhcvqpSdS0bl1R+iFmlZF5/O9Rv1HDio69k2nEpsgNnT60b5AS+fvlTr1xvfFOOPJS2piNEXT2a916qFghaZj33TeYjOODZ1TtCNo6cyEPbHWfN+NU+4/tYonC4yTk+oWsqvFOPZNpwybImzoKLQraOmU7Y0Jd2GfcWavxcj2szDjPJ6zZOzlROPwjsFN5ys2fmzoeNDGoaUTnvRD7O+8zqDjTiqW+lt0Jp2NZ20y3ZWVSce+6cRho7Ch40D7Cy2df/JlOpE=AQAAAACAAACABAAAkgIAAA==eJxN0VtI01EcB/DZxTDclNIaRcNiPuUeNnMibv8/sVK8QIL1kl3oIm6mphCkGWpF9KBRkD2ZuRKyWhY6YxXunG6jepiGvVSjRqk9dbebS6jf97+zOm+fh+//+z3n/A2tyUrQVaJcZc1qd8/kaOeuRs0T3MpKN5k1l0ebWIre6ICfLFdYUySTwQNTjmC1u15ztOu9c6GtUvOscY9y89RAEE6l/gD1+1gz76X+49QPh6m/iPrhIur/kGp0wA+pv4H6YR/176B++Dn1/7FWap6h/hvUD38suKXURlLUHINLlV13LkldEFuv/hibUBL+SX5ZYFCtkc1qufmT/wXZRtbpdB31lJlPmV9jE0w2Ot3UaTG4uOz+dz3B2ktmbUv29e2RoH2wRtu6Qs4n4wzHAp+DowVt2NIdFN4ybhgJ/M+z25KvUaebOrE1SPYIZ3bMsOiyNwq24NdkC1yxlpu3mbSthHGG03OF/G3Iou4vfOBP+EDuM3+GyOCO0rcsQ/Rja6nkaV82v1P21IFd+K6weZWH13Uucc7SVjb5KPk7uSXczl+NZTlXD6eNwCEy7o6MO55h+PZI/Fs2RZ3nqRNbcLdwy7p5fF9pmGHrkGRvXj7f2JDOsSX7xOIS/vWwiWNLNjIbKIOthGPkRL+8BZt2J7G03jUcWyuE8c5evZ15x/dyvHO/8DdyIFTMeEartiUbmT7K/KatPmGcIYs6DfHOf1vwUPJF5f7ldG0LviecOjepKF1l2h1hJxlnOJsTU6ardmpbZ4QXfYn59ZRxUAb/V7bUz4eF6Y7ccnKlauusxt1VOI+Muz+OblVr2i4w7MIeMu5bYWlUC+1DrN1Y7E8YZ3gkMnhb2E3GrtTPc8i5wn8BdBYcfA==AQAAAACAAACgAgAAzQEAAA==eJxFzEtIlGEYxfFxxBoUoV2arsRLi0BlaFO976xScZhCxaikCEG8tXDtGHkhUcGNJQg5SYpGY2RUkFTfo4iiguMqzMUgwjCDI2rkIi8peM6Lnz6rZ3H+P4fj7Dznr2NqedKtq146dXQ0plu33urE0kZ9MTCkn24uau+XPv0iHFH8S/H3hCPWc2yc2LgCQ7KE9gHa2GhM8pruqk/O+8YpiH5XNW9mjHOQGlcdE7vGsX86+acbOjloP6KlE/26aPX+uW2cWz+uy7PKz8bpDFTL/pM14/Dfw0/nJjYt2NCJoO1BSydZ+aThQlDR+R2flN38dONU9MfEn+QxTvnpT4ebv9jQcaGtQ0tnoKhCBr3dFp17D0WWa/YsOj8fbct/zxWhY/90KrEJYUOnH+1rtHSOszes9/VK6IznlcmHd0Ghs1PbLiOhX8axfzpBbMaxoXOIdgwtnemEFLVaX2WcO/5mVTIxZ5wb1waVp/2fceyfjg+bYmzoCNoVtHR8W1d1ZtEl48wVDuiWozbjdC1YOv3ysHH4p+GnM4uNHxs6XrQZaOkk5j7WO/EsN53M3AU9Nd/nprP+6kAXuL656dg/nQxsBBs6DrTbaOmcAH8SXhs=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0002.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0002.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="552"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1388"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1940"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1956"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1972"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1988"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2004"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2020"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2036"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2472"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAjAEAAA==eJxF0b1LQlEYBvAbFenqWiA1OAsJbeds4tVW+5CaRJewVZoyoaUxP/p0CfwL7pCQnQMFOVgouEq0FKjpFAQR1fOe+15yeofn/Xnf51iW9ytI63/WZwm/OI32xGs9K1uZvFhPCTlXC8pPeS5ut3PysJ8WNDcxH/XT6gGZNWR8taA+wW4Vu2/1rL5I+JXnPGbyao2dL3mumux4MzltZJLs4BtUhZ1Ow1GpUtE4B++Leio+EuTkhra2nYBxvJmcAjIWMuQ8YXcDu+RMh57VZLDkkLMQimndOnbIeSnv6bDv2iHHm8mZR0YhQ46F3TF2ySFzq1RU5Ozjv2bjI0XODr5h1QlocryZHMrMIENO271FkVPFjWfRnnHucTt61uR8oBP0bBxvJufO7VCTU8YuejZOzX0v43TdtzDOt/tGxqH5hp0OMkl2LrFbYafbcMQm34We5a/t3rU7tGWM78rxTA5lfmz3LnQi1vku9Cwmg6tl7lnqViDCPcuwbyXCPZuZe5YKGe5ZjLFLzh935ELrAQAAAACAAACABAAAYAIAAA==eJxVkk1oE1EUhbMpFFuNFglouhGycdsJdNPMI5BdCy3UTZHgT+yfYJJJjLTQRW2hP24K1k3BBpVGsC5anKILdS4BFbrJSjFqbWsUVBRx1Z3iufPutM9ZfXmcd07uuycUCk2+2svas7/G1N1Sq5ftT/q8msp4x9cXEwFH1xefM9+BJtef9JgPb253vNzL+nyv1GpfkfOHqYx9VPSHNrcfkfanZdwd1f5UgWdY+9MKOKL1dBuay9qHcLeDtD8h1x6Wc9y1w6Jfjq+6+YmY+ns6pUL4HPAfcEus6n6hEXXJemM/fvvb/QweBIf8b1JN18Ibidxrl5lPnogGeo9/M4+Cbw0sBf5URpYjXEhXvUJbk59l8nytmc73dPlZc+AL4Az4xHiEnkV7/SyT50TPWQGPgPPwdODJWY7BU7l2avR125xl8v2zafpQX7B5XuYtMOc6Y0W61ln25za5IhrOrcjdYTB77mrP/awg92dftxfk/hDmu5/qCx5nrYAb4CFwHlkTnWX/LU1mzQ40PCPzLphzr8PzOzw5i/mrML9Dsa2JOMvkGbzVxZ4u4qxZYZ49grf1or3EWSYHes6a0Xsh/g9ZvTviLJOxawu79rNuDiztM3ploVckvbLQE+JdJ3Jn4uiSn4VeWczcsUDDWS2xZJx5SPfKQq/+y2Iupau2IzNeBReEb9Sa1TmZMWCe/eR4RKFLdGrtm8v8FHzsyAN3/kDjmcyeeZmxaPB0rl01ZKfMH4XRJVXXO+JeqS3ZNbqk0CVv7UXzRgFclP2y5h00g7pX6v3BftWO7HRK/Jn/AR4VDHI=AQAAAACAAACgAgAAiwEAAA==eJxF0T9LQmEUBvCbFTk3WlODs3CHJl83SW0Ts6TanMS+QjU02Kj2R0qiwC/QHRLyHqEgEwv9AA6BJCjpFEgR1XPee245neE5P+95XsP4+4X+R6NeiuWCp+G4eq30VSM9CSZTpObKF2oS8il7a6QOur0gzzXMh92e/YDMGjLe8gWdYPcYu/1Kn85iOdt1ntITe02cz5CPauK4MzstZBLi4BvsI3HaVZNSBY929t8uaSqa0U522KSIldeOO7Ozh4yBDDvP2F3HLjvT/m0aD66u2Vn0P1K9MW+x81L8oIB32WLHndlZQIaQYcfA7gi77LC5WfAQO7v4r9lohtjJ4BtWrTyx487scGYGGXZazi3EzjFuLIXj2rnH7ehZO+/oBD1rx53ZuXM61E4Ru+hZO2XnvbTTcd5CO1/OG2mH51tx2sgkxDnH7pE4naqpNuQu9Kx+Is5dO8OmWpG7sjKzw5nviHMXOlFJuQs9q/FgyZSeVb2RN6VnFfDemNKznqVnRchIz2qEXXZ+AeHPZnU=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0003.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0003.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="652"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1552"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2200"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2216"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2232"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2248"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2264"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2280"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2296"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2732"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAA1QEAAA==eJxF0EtIVFEcx/GrYSru3Bg5IYlomtBD0Tb3HFv4uOZG0LCgCKQpocGdJhpMQvjIhVBCPmZTyKgoYlchqDmnKDGoQURQIhMRVHR8rCoSoX6/g5fO6r/4fT+LY1neC0rr/60HryWrF2WLYmPYL7/ebVbXbwqZGMqQh3JAvbsVkE9W6oV3d6/Uqy/Y1GKTFMrQ/Wj70G4O+3XV7og6U9ZrnE+XTulHR3HG6fhs69NpmcbxbjofsWnDhk4lWh9aOt8avis37qlNx5ks1cWthzadkvYmnZ/vE3R4n8dNpwKbImzoLKF9jZZOsh1VjSfzFJ3l7Sv614V+Rae6z6+DCVrR8W46S9j8xIZOItoAWjo3nrWr+TeucazKmHq8e1bTcdxUHdhxNB3vpvPXiakgNnTq0EbR0nEbUyJu0w/jBK62RnI7y43zITwUic0/NM573Du46TzA5hw2dKbQTqGlszXtiJ6DWeOItzOirfaycbpC6+L3ndvG6Ty+6djHGzobaLvR0hltiIijrPvGmQjnybGcBfM/r6I1cu9evHG8m844NqPY0Amj/YOWzonsVbG//bKAji+7Quq51EI6a89b5MWk4kI63k0nHRuFDR0L7R5aOv8ANutGHw==AQAAAACAAACABAAAkQIAAA==eJxN0l9Ik1EYBnBH2JaaQRNCQl1GBcGIadmW7nyWWgrmJFZSIEVzK63VtBKrEdHN+kNOIu0PRVsS4U2QzuzCnReUgRgNQsgwFLyIgtRZF12ERe/7nfO1b1e/i2fPc87hW6hZxZOd1cy/4bLy9v4RPvAp4SQnXrTxeevcKNkcdvDW2vWcfK+nP+561ay6yWN3Jvgp1ZktFtZ1w6ra0OZhh/dfj5O/Yv+k6Ich7I+KfgDsT4p+yMV+r+iHbuyvFf3gxn4u+sGA/R2iH1ZaPaxR9MPz4DCPJI3KbFGN0o9+hp5DZ2cZ4EfhXuV8wzTTe8aRC7bPbiUDf3rnYCaFmQsN05zyy+iL6Gi6E7R+3IIn7jxwjN9ktKX30uIhGL8yxmiLnED70ebgaQgf+8hoS7NhKjC4IDOXcIvyY+h29FPstGOntrVH9EO0tBhKeh/FaYu8W7rnpQ/+eGfitEX+hT6DHnVcg9DIcjxmD9k00xnCMkNbYfnfADqCnVbRqd+CD9UZkKqY5LRFXkLTm4/4ymDru3VAW8PobWi6eyirDn4GC4G29NYytPUGvQVNb06di6L//xbd3bfpJDc584G2WqTpDKaJCO/7dhTO4ZZRmnYryl7zRmtA3apEu9BTm9fGKNOLGdrKlHk6gzfdr24Zpeu+/3UaSyzq7j60STq/chfb+d6jbm2Uxh42kTjAeN5VaL61JpaUrm8/MWhOZ7jeVel+YNJ099V8lhXPp9S3JVvQdN+DAwXKw+7t6lY9+jGa3vxLwqrcXSmHjvKqIc10d12e623EziLRCXr3lRYoZ5ts6tYDdABNZ2i8c1zJ2RHktEU2oekb6/J0Ko7ftzlt6e2SGdoiZ6PpG9P1q1t+6X9tVw4IAQAAAACAAACgAgAA0gEAAA==eJxF0E9I02Ecx/FfRmp06SbpvESYoVAyrNPvmR2SZnUYoZihiCAiNrx18A+oIDnrZAlGDakYw1GILnDgfl8VFRUTLzEJJARxOXV68s9UsM/nwV89p+/h834dHsP491z/T2PiwyOfNVD6VG0E4upH/aFVUSUqwz+ojl3ZEq1Oqu7VddO+e1fXrUVsyrHJ9A/Ke7T9aOOBuDzeyZfc0qvamSkakPbTTu28mrckO+uzduybzjQ2bdjQKUPrQEvnV+NzCV+4YtJxD8/KvdYWk05J14EUFn406fAuwE3nITZ3saETQzuKls5l84k0p4csOiuJiBzcviZ0PP1x6bjkEjr2TSeGzT42dDLQetHSefY2TZYjTqFjlDVJ584n7bjDfeLdWtCOfdM5czdJBzZ0KtEuoaUTbn4dDb+s1o73/kn0Vs+cdqaCDmt7+Ug7k7i3cNN5gU0+NnRG0I6gpfPn+4L5Zu+BdtR4sWorH9WOz1+nDmt/a6fn/KZjnm/obKDtRUtnqNFUpzc29f98C4ZU6KZHO1+WfqpkQ5d27JvOV2yGsKETRJtCS+diXo3aTVx30nHkzauJuT4nnbV3KXUnc8xJx77p5GAj2NAx0CbR0vkLAXZpqQ==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0004.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0004.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="600"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1440"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2036"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2052"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2068"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2084"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2100"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2116"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2132"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2568"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAArgEAAA==eJxF0UsohFEcBfBPwljYTMmCks0UM0pMM6XmuzaY8dp55JWaTEmzJckYigWy8chrNmrWylAK94pkISYpkfFIUd4bG2ycM3Uzdeu/OOf3zf1fw9C/sDD+ZxXfisnWmVHzMRoQI28FKqXm1cyI5Ivgi0/5YlYxlvCbep5I+GUYGQMZSyRfnaDbgu5TNKCueq5lLGXSQ8e3Vqncgz8eOhWjfcrhyDPpcLZjpuNFxoUMnQt019Gls1B1LldqMyWdplZTnXb3Szo7HUH1K5YkHT3TaUTmBBk6c+guo0unKDsii3HoxMez1BkOnezBEpWDQ0fPdHSGTiF6dhw68/AW4dI5wHea8T06X/j+Lv4HHT3T2UeG/5vOLLrz6NLZw/0ucU86Dbg370+nHPsQ2AsdPdOpR6YaGToSXe6ITjv2zb3TScc7DOM96NThfXrxTnT0TCcNmRAydNrQPUaXzvTnoXm34Us6ocZS4d7eTO75u6tThCMPyT1zHsZMZwgZFzJ0ptC9QZdOqu3W/HheLaOTZ/MKdWR10rmfHRAlFreTjp7p5CIjkaFjoPuOLp0/uB8/9g==AQAAAACAAACABAAAZAIAAA==eJxN0ktIVFEcBvDotZAW0cOZIuuqNGW6cChRg7kXpybDaR0iUZjoUAQSRM5EIBFKZmhjC91ViyIXQ+Vsu+dEZoQtyhaCPaAIo5dKjg3OHai+73ouc2Yzv8v9n+87nHtS1c1i7bZ0aLY+YTmNZ0T/p6En9PaeRrH/2pJNV+F/B57pGN7nMUcXYV0K6+n3C0Ezs+xzfamvzZy60uKufYD3//zp0Nf6hPyDdX1YTxcjrwK5dDn+/Ximu/Cec/R65N/Henoa+fPIpy8gfwL59Eh+q5ztjpsDvyMW/RkehI8Fj8vT5x+b/caMSbcpn7p6Tm5eGDdX4ee5pvTEWFTN3zRmBOdb4QHYy0S+HFZdyJfOdKnc9SpqsysPb4S5hyojJst7kvZ1dNH74BtwrqZb1j68Y//tPRD0zD1Uqhl20WUw95BTmV6Xobx4tkgG7o0KdmXg3cp7UxH5IrIo2BWAX8KD8O0jLTLxbJ1kl+49mBnHDLvoiZV5wcwyZLJLN/+X8MwuQ/NTrKvAeuzffK7Mc76InrvoY5duWZgXntlbojLZtVPzt8mozfNl10fYUV6Dc+L5smu15i04Vwfnyy7d3gy7uLZSeVllsut7IV/+wnfm92bXD3hEuQP3gneFXTFlnrkf9+gk7hO7dHOmCTPsaldOwj8L+XJO89CXrDn/4a37TXVnm6qteLLY7fXMXmc0bNWGA25XDq6D6yYPpjnThRn26tYy5S3Nb96VWL5hn9ulO9zZamUuNwv20lmYdzs0F7cOb+gUj472jtGHYO6hQc3wXjWotfzWzNy0kilfq3ye+X/+nEIeAQAAAACAAACgAgAArQEAAA==eJxF0d0rg1EcB/BnhJVrKS83LlaMUouV2pkb7y838tKGpFxI/gEyoyjCBbPI1nKxazJFsd9EQprlRtS8lKzIuBHJje939fDUqd/F9/s5zzlH0/4++/+oRWK7FnEspamnYEJNvK6LoXFIZfkDavjlTBpCi2oq/mjT59n4Y9iNjIaM0R+QKLpd6CaCCbkZdErIkG2j07BxLNbRERud6slPKS312ehwNmOmU49MJTJ0rtDdQpfOSm2b+JpmwnQ6HCIXA19hOvs9Sfmx5wkdfabTjkwUGTrL6K6hS6ckp1DKsOjEpuflEotOzuim5GLR0Wc6eoZOMXpmLDpeeKtw6Rxhn07sR+cD+4fxH3T0mc4hMvxvOh50vejSOcD5rnFOOq04N89Ppwr3Yce90NFnOi3I1CFDR9DlHdHpxn3z3ulk4h3G8R50mvE+Q3gnOvpMJwMZFzJ0nOieo0tn4b1G3W+fpe7Z1b6lrHsVKee77065/f0ph/M4ZjpjyFQiQ2cO3Vt06aSbetXbc5GFToHpVEVOFi10Hjzfqty4Y6Gjz3TykRFk6GjoJtGl8wv9A2GCAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0005.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0005.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="548"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1320"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1868"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1884"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1900"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1916"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1932"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1948"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1964"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2400"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAiQEAAA==eJxFkr9LQlEcxR+E+iRcIikoECKknoQPFGrp3i1ao71FsBr6MTRkLhLk0Bg1NNgQ+Bc4tN07OlXUoA0SQSQ4aDVka+fI99KDC2c45/O+nO/X89xX0d6/tmPpVzPozTU+6kU9m163tnnRiNVS+u2yZEP/rnHWKSinzzsFMwOPgcevpayHbB/Zbr1o46v35iAaGHLavRU7zF4bcjauirYSsYYcp8lpwfMDDzkxZPeQJSdI1swSHjmP1YR9wiMnWQ7tFB45TpPjPOQsIpfBI2cXvHFwyfnGf17wP3JO8P9NzEGO0+R8wcO5ydlG1keWnO7WUY4dkXOT6eTYETnza/E8eyHHaXJq8LAjct6RZUfkHEYDFZd5frPXqiXznEbsqBdynCZnKB5y9pGNyTzoRgXSz3M1MeqInOlyqCelH6fJQTf6QfpBN2pB+kE3akf2hW70p+wLfeiS7Iv6WPbVFg856EYVZV/oRg16tzm5H22bE3m5Hx36y3m5n5GW+9EGHrkf1UeWnD8iOjHxAQAAAACAAACABAAALwIAAA==eJxNkztPG0EUhV1BE3ATpUGCVCHhJedVUHjGFbbCQykQFY4gFiSiQxFCwD8AgQhlqkju3MVr6JgpwJGgASykJMZAAKF0caCFIufs3JXHjb/VnnvO3HtnF/M586f99fbk2IJev0uZmduYIX/E/2c8kyt4vwQdGdrkojC0al00G3cp9UFqoVVH4jkHbdWxXYF2ymnse/yvulp7gPdzztNCm4wYZ1DLooFW5aQW79WBeGan2+1O/H577euAHgcfCv9rztnH+VfmWaGqyG3gTrB5uGT3y2kTw8/numh6C1VTl9oeMP3LzjPM2hX+m2my158CE2aBL8Gr4NJ8yg5/idmnyPoGfgvuAz8/GbXV/lbLLJ8DaEagYRZ5CMwz0PO387fkC2Hm8JlZ5+AbMM8wiDpmo1bRj17s/RdyXiCPWT5Tv+n0JqrFOU2t4WlPPS6i73fon1klj1swJ863C1lx8A2YuZuYq8V8meUzNZwvsx5ILc+wBc+s87SBx8fx+ySZ/VY8xn7CvTLrCZiemKHaK6fDHTPL5zbRMLejoTffxZNZux5j3iqa86Uw+8VsNWfb7eYcMnuv9bfqhMzWZ+xf8x4wi/oiOAG+gmddZnvt8W2mSdfkXmH2+kzuFXYV7pi55DfCL09G9Q+5S+Sf4Ef7HUEgemZFevZOz1O5S5E/GfsM98osnzFjzT2xR+xWx+Wbwj4195qYnSiSS43vKNQwi7Ut8k1hrnqr8R3pQPg/OGcc7w==AQAAAACAAACgAgAAiQEAAA==eJxFkj1IQnEUxR+E+qItkpJqiZBSQukNTV63toZoDcc+hj7GyiWChAKXqNGEwMVJcqjFv6NNRQ3a4BBIDxy0gjLaOkfuqwd/OMM5v3c591rW35f8l1Z1IJwy3fbV9WvBlYnwnanWhsuBXF5ezn9M3F4oHzdbCU+fNluVcXgMPHYubyxkO8i6BdcMJpbMjr9YIafRvjW9WMiQs3zhmkNf0pDjaXLq8HzBQ04A2S1kyYkEJ80cHjkPmax5xCMnmC6ZUTxyPE2O5yFnFrkoHjmb4A2BS84H/vOM/5FzgP+vYA5yPE3OOzycm5x1ZG1kyXFTn/PsiJzL6KrDjsiZXjxx2As5niYnBw87IqeFLDsiZ9dfTAzqPN+xkNR1niNfst8ROZ4mp6cecraRDeg86EYi2s9TJtvviJyxdElGtB9Pk4Nu5F77QTcyo/2gG9nQfaEbedN9oQ/Z131R7+m+GuohB93Imu4L3Ui3PeXo/Ui1dubo/UjcvnH0fvpa70cMPHo/0kGWnF+4sFN9AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0006.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0006.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="564"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1368"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1928"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1944"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1960"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="1976"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="1992"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2008"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2024"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2460"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAlQEAAA==eJxFkb1LQlEYxi/0patrgQTh0hIotJ2ziVdb07SPRXQJmwJpSQtaWv2gJBsC/wIXoTq3j6FBRKFVIoiEtFpqjOp5bueQi6/c5/n53t9rWeZTlNb/7HRaTbVW2lfPjawsvM46E9GRmqr75ebQdpaaPuegnxZmPuynFTPjyHjqfqeNbgrdQSPrJPHdxW9yLDzfQ44cG70c+uSYmZwfe6SKyJCzgi73IKca86rj8L3Luc3kVSIlXM6nrKnL9ZzLMTM5N8jEkSGnjG4VXXIGG9vBscCDyzmd7wdnAhGXMxf2hh7LOy7HzOTUkZlGhpwndC10yanHvOJI79PL5EVc7/Mla+JC78P5XO/TRWZZ73OCbkXvA8eio/1MRkeioP3Aq+uaHDOTgzuIXe1nFd229tNrNUVS3wuOJT2SszW0ZUTfK6dncpj5tv/uhf8XCX0vOBYV+CIHjuU1PJIDr/IDfskxMzl4b3mFDDlwLErokgPH4v3lLEgOHEvnzhciB17lgmcxRI6ZyYFjqZAhB47FG7rk/AL4R0WRAQAAAACAAACABAAASQIAAA==eJxdks9L1FEUxcdSpE3Nqh+bMKa24sZVzXvWTAnB4KTpOAq5yFU1DoNgE0T9AYHQGLQqWo7lz1QQZN4LAkFsM4uUEKLUoQE3IRZEm8553/vVRwOP+cC795zvu/c8b46ZFziXc4/0aqZa2c2lHP9IRiv9y3cdHySj8Yzwp0w1vi01E80xNSG9tVxKWfST0afYTx7H/XhQY1dw/y3otTXcdweadh/6t4Q/Qv+r1JSg/0x60acqgb5Fn6oF+rYnv2P6cM60dupuj68WYzaJM7O3pa4JT4P3G9vtL5wIfj534P46zuzelgl758HU5Dnb2mnT+O8P9O1UU8ls3Dxl6TXt8cN61ez+TdkpeBXBO8Ijhbo5dm7YefnMmm3U0GtM6ufAk9DcDDQPvfgNA4m1SnzzvPPKevy6HDW2d9h5vRF+B063tZhLXx47L59ZY1BDr7CXbx+E5hVo+l7kkcRaPPR64PHbclSFXrPCnPP9thZ1UbzugOmbPHFykTVGvJaEsSOTg2bom/d4vqmkPsts33v8pF5VnBu9yN+FC4W6asBs/1yILI6BIzLnp0c1pii9nPmMaP7nZbFnlZYs9YJxzGkwcuGyxTkjL7pDMva7sV3/lCwhU5rZejm0vpCQenrdOKo3WWh2SZZug8OMYecuT/Qll4WRKT2KfGBuChnRzA2/AW/VeeSJ7z0OvgfmN4T1fC/rmUvuGjnSzFboVRbGPjX3TS9yVhj7dNmi1wcwc8NdY5+aeaKXz0Zq6MXeV2DumprMlu9F/gdCNhu9AQAAAACAAACgAgAAkQEAAA==eJxFkT1LQmEYhg99+husKcKlJTqzj5uktkWaZm5OYj+hj6HBRr8o6CQN/oKGhPK1j6FERH+AQyAdSLIlQYKo7vv0nnLxkXPfl8+5HsP4+wT+R6PRrpkqWZhQz1Vb9l7P1XQ4o2atimQGTbV2kVeHvb7fnY96/TozU8h4rIpqoZtA167aKo7vDn6TY+D5AXLkhNDLok+OO5PzHcqofWTI2USXe5BTjuTqJ8F1h3OfHtdjCeVwRgGvqm8PHY47k3OHTBQZcoroltElx06NViZ9KYdztpQ0532PDmcxmDOfih8Ox53JsZCZQ4acProGuuRYkZz/WO/TTY/9Ub3PZ8Ar13ofzld6nw4yG3qfU3RLeh84lrb2MxPOOK7JgVfHNTnuTA7uILvazxa6Le2nWzMlru8Fx0KP5OwMmrKq75XVMznMfIV+74X/l5i+FxxLCb7IgWO5hUdy4FXe4ZccdyYH7y03yJADx1JAlxw4lreXBZMcOJbGQ94kB15l2XNpkuPO5MCxKGTIgWMZokvODxRzaRs=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0007.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0007.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="648"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1548"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2192"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2208"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2224"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2240"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2256"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2272"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2288"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2724"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAA1AEAAA==eJxFzE9I03EYx/HNUCfSZZeULfxzkBxB/hlNhH2/GLRpa0GHCkxFGA5GmeJhGcspi2BUhNAaTFyHQOqUjBUE8fv+tBIFEQ/CGOgsAgPnMoJIkg5+nod++Jyew+f9MpmMm5Km419P+qpUyrOhduaC8tPQXXWjV+iV6Tr5W84orX9Yf7gVEMb/aCugPmJzHRtLuk5PoE2i/T4X1LMj1Vo2XGBnuCuiNce97Cy+mtX21sfZWcBfxE/ObWzOYENOBm0GLTkL5sfufGiTnSuRQ3f3/EV2Os/ahYyF2TF+cvzYeLEhR6HNoSVntMIhqtxr7BycS4ncbgc7sXJdXH0eZMf4yfnzf0POHbSVaMnpexYTa++z7FRc2hOTpQZ2Lmet8laxhx3jJ6ccmyg25NxEu4qWHH/ptbB7ptlZaq2R9/+Z2YmvuGXtqUZ26K/BT85nbCLYkONDa0NLztOfS+LL2x52otfapOvDO0XO38EBOZX+psihfxI/ORPYnMeGnCdoC2jJyZTlRf3oukZO8MUF6djpZOfB/Jj8dTLEjvGTM4RNMzbkvEF7Gi05J5q2xf7uy3Zy7E3dUl+2Osn5mrgnWywuJznGT44NG4UNOSa0P9CScwRvoUArAQAAAACAAACABAAAkAIAAA==eJxN0ktIlFEYxnEhJzLBxiuRhSJC2aSRmTjonKMtmjLogiNqapqTllESBMlY2AW6EEVUUIukKaxFoAt1UFG/79BFTMtuljZlasTkwk2LoJKSnvfMiTmufouX//MdNXch01j2s9rsa/bw1HhrnjWzVtoe6XH0Pa6QXrp6xrEveau00ZnI5hrWSJf2MHbo84JB/rWhhJ0buiO9+5mbPWifGCAXor8E/f5mj0hBPwJ98ib0feiTF6FfgT65F/1Z9MlF6LvRJ/9Avwl98nb0W9Ent9vmjfXZq8Ta207u1WyzZ5mjZ2uEOzDJUpVr4Y5BpyniTogw/DyBTXj2stVHNy9wczAwaSaq+zq4D82MYFPfEt3Vw3nhtmS59VBzf0y0gw/Wya1WZfqG3y+THZ7RU6Lxb5SPvwqavqE1dG+ehBl8AG4LNUWP5kBEBgvfskJuTcMW5eJHTSzWuVdulcMxMH1Dwfwl1ug+Lrd0F6p7eq9Lmd47E+oLv+bX91vY9Y+RcuuN5j0dX1jD6W1yq1R5P3xj3TwLlFfJLd1VuDmMG9oqg4/A9TD1rwWb4p3m7hY/K66fM2mrFy5S9j5dye230uTWXTgHpm/4NpjOr/zJlVtf4avwsY1jXfdwk40beq9uarqCTaE71mnhLLFTbsXAm5X9i/P51I4wufsBnlbO+uTi4/YoETfi7SK/h2NHkrom1A1t/Tf9falZEGzKrXzlipoEbpurlFu6L7aV8rdTXpO2LsDjcA28M/0od2R3mGeWD3XugvNgevt5dUO7dD8G0++8Es2UYFOUh/rCnpHEn/feNGiLPKxsKavlCWl+g7bIVpj+xwbszby657tBW7rDcRONG9oix8P03pxQX+j+B79CFl0=AQAAAACAAACgAgAA0QEAAA==eJxFzE9I03EYx/GpbBohdCt1QnQQDUFjlBD8ntFBi9YSiTL8RwQGstKdOqQ5XQRm0cHWKHBKgQQdkrUgSb9f13RMCek2OmgFY4Mt/1DITOrQ53nwZ8/pOXzeL4tl/5z/X8t80PVAPW+6pNNTGVro3lGtbVoXhyZp21muVeeGvr+aMsx/dDWlYthcwaYkNKkDaINoM1MZHel7OBe53SnOrTN/5mpGEuJ8fGVXPz7/FieKP4efnZvYVGPDThhtGC070YKDxpeednEu9t8xzk3HxTldO244/XlxzJ8dNzZnsWFHo02iZcdre20cMNzi7NSVUTI7I47f6qSWpxlxzJ+d/N6GnV60xWjZ6XhSSCszDnFs5z3kW38hzoXIGHlyy+KYPztWbAaxYacd7Se07LjXq8nedEic+IlnNPB3WJyRJUVlh1+Kw/8R/OwsYtOPDTsutBVo2Xm81Ujf3i0rdgYvv6WG2ZPi7F77SkOh6+Lw78PPzl1sTmHDziO0a2jZCRdepaPeZnFuTMToePqDYufe9C/6WZpV7Jg/O93Y1GDDzhu0lWjZKarqos3sMQc79qolmk+MOdj5Htil+pL3DnbMn50KbDQ27FjQbqBl5x8yNGO1AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0008.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0008.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="636"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1568"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2200"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2216"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2232"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2248"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2264"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2280"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2296"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2732"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAygEAAA==eJxF0U9IVFEYBfCJqHThZkgQEobZDGEZg0qu+r42DfOatpNkKYIoRIzLJCb/DSQ1RZtposS3CVymi1EQpnmvFtIiyn+LiExDsEgtFy2iiPScj3l0V2dxzg/uvaFQcEY19D/7bqpWniRWva2pfl3qG5TLneIfcyP6VyfkRVfGv7PWK8xl5Pxar7eIThqdGjfiT2JbxPbLVL//ddaRB3sL5kh5Tm6nW8y5527Kr55uc+5WM51z1Q6dLWzz2NK5VsjJ2/mSOUcv7sjIbtScS6Ww3th2zAkynSPoDKND5yq2b7Cl01zvSlO9a87KeJ0ujteZ05CN6/Fs3Jwg01lG5x06dE5hexJbOkvzJblSyJkzthvVfWfHozOw7WiyFDYnU8102PmHDh3cQzqwpfNwb0E2Zh1zhtMt2l6eM+d3T7eOupseHeYRZDpD6JxFhw7eVT5hS+dpYlWKqVpzOjpFX/UNmlPpyuhPnTAnyHTwn/oSHTqPsS1gS+fD9Y8yfeh+hY4zc0HPZP9U6JzP3dTY6UZzgkwniU4zOnTeY/scWzqHY+vy49uzVjqNsaT6r8NtdD4/uqXxmvY2OkGmcwIdDx06IWy/Y0vnAPf3Pa8=AQAAAACAAACABAAAqAIAAA==eJxN0l1IU2EYB/ACRyFdZHPSxyLyQsIyI1Gz2vvUEBd4uURaH1phQhZ9ydI19aIbaxflzI+bSOtCvFnSwivPectAsBsFoYthkC5rC7chsmIi1f95z7k4u9nvjIf//z3P3rxkxDVY7NULQ53kn0+75mJuZU9bodBmypTxLfCsvBBzi9b5tMYeLvaKXCKiHKi+Ir60NBi/L1wX3nvPpti/ExFXGPmOUKe8i/xZ5LM5fxL57Cnkn0E++zPyMaexB5CfRD77PvJTyGeHke9EPvv2bLuIa3b5JOGhm6Z74a2vJ0SqqkH2D30V2+BV+AVsz3wSTY9vybLFvPdO+DJMBxffbY5OiLQxr+fgjDGvX0LmdyNfWl3tHBNdF7arrpNwEOYzDJauid0ztaorDO+F+Qwd0zYaqfPJnZ6iaCf8Ct6Cz0vMFBnzej+8Bx6Ca5D5yMiUAg6Ybp6cE0cq1nXusrpryUHLwXIZRhc7bvq0u4Sy427VZXU3Zr5hhruC8BI8DLcg85CRKa/BpaYrKtZF4+Sc6joKX4X53VeC5RRYcqiun/BDeADeHHdTpbtEdeXgGjgbjUXRQ+hTXQnYD/POjyHTZ+TLw3CTaeyYTjjHVFcPXA7zGZwztRQqXdN5z9gxYdc6n2G0zkf+aZssOJWNvoEfwPnY+X7M9GKGu3i+Dx6EsWPCrvWn6LLkyxXNTr7ZdtVlNe4F/RmdUF3snGncKcLd0itxl9gFML877hRtYIa70uY8+wcy65GJ95K4U3TRyJf/uvfRWa9DdbGrTH9sbaZfPY2qi52B+2BXqoPqdtxRXVZLzKQxw10f4CSM/0X/i8x6I9PaJVfbDtB5eU7jLnbAtG3XDYrHnmvcxV42vVHZQ/lvRzTusjrPnOEuqznzuJFp7ZL/AcZQNQ8=AQAAAACAAACgAgAAxwEAAA==eJxF0blLXFEYBfCJEhVsFYJLYzGEuCA81Op9Y6O4pJNRXBHBIgzxD3BcohDJiFrMaFDwIRaWLqgQYfKeppBkCIlLEwQ3EEciTiwCGYSgOedjXrzVKc75wb3X4/l/fI/Rs201hszZ2ibnciku+71Js7nNcTKtBfnry5OPnQnn7fGFyRxFHj++sPfQ8aOTZS0489jOYBtfijtXmzFz4rZGHYlWyIB/XZ2Q1SPJ7lN13qUyHTPVoXOJ7Ti2dDoiafJty1AnoyEgwzeL6rzcCEvgOqaOm+k8RWcIHTrt2H7Flk5pbqG8yC1U53BsUvbGJtV5FlyTnOCaOm6mc4DOd3ToFGP7HFs6+1uGtEbS1Bm5WZSH+oA6fdcxqdsIq/M6lemwc48OHdxDWrClM3VbI2ebMZvOkH9dqqIV6tx1n8obq0cd5mFkOoPoVKJDB+8qJ9jSmattkpnGkDotbY586k3adOzOhPz25anjZjr4T9lBh857bCPY0jl61S4rT7LVqV/dlbJgvzrVo3/EWzJv03EznTp0StGh8wPbZWzppHu75NfPIoNOgfeLbH8OG3TOp++kPOuDQcfNdPLRcdCh48E2gS2dfzzqXzs=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0009.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0009.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="636"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1580"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2220"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2236"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2252"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2268"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2284"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2300"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2316"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2752"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAywEAAA==eJxFzE9IVHEUxfFJyUakjVsNDWLSIVNKVIR+14JyhpaaUlAEoy9n4R9cmCKVGkFUtDEDo2mhyGDoiExCIO+9XIirwaKFRloRGKipSCtDzHMu8+iu7uJ8Pz6fd33i+/+7H98nzfXBAWdtzJL+3yflX3jTORYrkLaNsISSue6jlYhpTf9PViIONwfY+GMFbgptI9pfY5Y7HrXN/qkWdSbjQXl7+pM6o6l62bqToY7305nAZhwbOnG0e2jpPN+ZN9/fhdW5f+2cVM7OqLN3+5b0xX46dPg/wE/nHjYV2NB5hnYVLZ2cCynTkhVUZ3m9SnZKh9WpG7Kk56irDv9u/HSW0hs6frQWWjrDVz6boavZ6jTeMDLXfFcd+2ar/JFX6ng/nQZsPmBD5yXaQbR0pjOWTWHHok3HenNJgmvV6jyc6pTd41F1vJ9OMzbF2NBJoD2Bls6X6FeTOPJUnfDUZTnb+9emUzPQJYEz+ep4P50QNiXY0FlCO4mWTrJr1STac9QpflwrTRd71dlc7JbZ+Gubzkb6p1OETQQbOtNoJ9DSyQx8M9vrI+fp5AdC4i7kltP58aJHyvyV5XS8n04eNg42dHxot9DSOQRS6j/sAQAAAACAAACABAAAsgIAAA==eJxN0ltI02EcxnHRrItKLZoZhE6SJpSEUYqW/x+UpIJgUoJkJXhKzTQWOaZpdRFoFxVlgeahm4huks1Zgdv/TXBmeepoljQRalsX5oQIFDo870GcV5+L377PO1x+e4YWW/zHVXfbShm/jmhjUx7hBEOeNvZTF05dKNBOfu4SfmAp0mx3LcKPHhZrjsVk4V5ziRZbPeXkzvtSqsVlRApnor9H9lkK+qOyz3agb5d9thf9QtlnHeg/kX3Wg75X9tlj9GNkn+Wgn3tQ9JljeA2N1tl0PTqbBmCHctgE0WxiCKsO9WhL40SLcBmcPHOcZtIiWG7CQl8q/A4Owd8/3HhxUxnq0f/CfrgK7kdzCE0Wnc2ew07ZZ75j6+n7xk6x5YXnlV9n5lBL7Zxejq1J2AyjqfmLiql197LOt7zwTdjRsqFv5YZv8c9ehc/C39AMyCbzr26xxPBN9LX/mtgywbPK/qZ8spgGxdYP+KLy5kuV1HZiSl/3PmAPtg83DbipwRb/bD3Md3eh+UY22U54Trn1rYFqDafEFvc55fKaQrL29ogt7mb4DHw06Tylp9j0ppiX9nx4P8y/exluGnHDt7iblIOaYqtK+YJtGx0qSRJb3IeVc8JP01pLg9jKhrfCFbC1tJ5Slq+LrWBn4caAG77F78Nh/DZ0M5qZssnMq1vsVfd2Gkpfcon/Kdyh/IJK6GPYPrE1CI/D/A36lkZyu7PEVrD5/QRu+BaDP8D8DSNo+tBkasst+2y+LZbum+6JLe4OZaOhnH77p118Kx4egPGb0VxpzWR6FnDxLSd8Ay6YjHAY1Q3f4vft8l4PaoqtTmX3rTg60D3i5Fvc08qBKxX0yRsltrhzfVHiDdbxyxQ6aXTF2yMdDXDyhFG8YeWGby3Ad2D+hmE0n3aJZvAW+w9q3gzcAQAAAACAAACgAgAAzgEAAA==eJxFzNtL03EcxvFpqAPxD/AEEjIPeAiGdrXP6qJwSIhInkIRU1Ok7Eo6kJURpIUXnkBoiogMh05MQVF/v1kg5oXYRWDBOoA4nDpFhWwU1vN82U8/V5+L5/0ymc7Ofv6avJ/mrFLRE6lvjfrl+d6w/HM06zHOIbm3syoF0936S9+m7W747/RtatycYmN2DulraMvQ+kf9+liTTf6mbmt0JlxucacVK2dk7bME77Qrx/jpjGMzhg0dF9oQWjpdB9fkx8yqctpuvpPLC3nKCdV8l2fOWuXwf4qfzhNs8rGh8wbtN7R0Ym03pDHarZwvgTk5yI1XTkmfXx5G2ZXD/wF+OhvhDR0z2ga0dAaul0hfYYdyyip1eV9/otHRqoJybE9QjvHTKcVmCRs6/Wh70NKZiiyXlPtFymkY/CCZW/PKeTF5JIdxAY2O8dOpxyYDGzoetMlo6XxtuiWeiFjlOCaXJefxI+Vcaf8llqy3yjF+OgXYZGNDZwPtBFo6061V4ml5vUgn49WK1F39s0hnd/23LLiSlLMT/umkY3MbGzpTaMfR0rlgqZb9wEUrnSTLR/GudFvp/OwNySXzrJWO8dNJxEbHho4JbRAtnf/veGN2AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0010.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P00T0010.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="140"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="208"         />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="352"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="368"         />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="384"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="400"         />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="416"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="432"         />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="448"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="884"         />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAVwAAAA==eJxjYICBBnsGBHs/s9o9u3cvFxk/XZpmL6PmYb//uJAJ+1x5+wdTKu0NOMxNWu8k28HYXXeS90kD1ewDquGYK7+fAaj3LVDvs6Vpo+aMmkOROQCozBUnAQAAAACAAACABAAAIQAAAA==eJxjYGBoYEAAWrDpAXDZh0t81N5Re0ftHQT2AgCabwwBAQAAAACAAACgAgAAWAAAAA==eJxjYIADewSTYT+zWpzdu5dKxk+XPrOTUTtht//4JGP2ufPtHkz5aWfAsd249c5jWxi7687jvdJANfuAajjmzt/HANT7Fqj32dJn+0bNGTWHEnMAKURAqQ==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0000.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0000.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="172"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="240"         />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="416"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="432"         />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="448"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="464"         />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="480"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="496"         />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="512"         />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="948"         />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAbwAAAA==eJxLX2K592iVja1Web19+hJLWyB7L5C9/9jpE3aaTDW2V75l2Vc2O9jfPd9i+/iNuv3d+jJ7uYVJtu8d2u0Oray2b9jPZzvL2WJf+G8/+7/7v1h3LRLb7zznk12p7fo9KXGJo+aMmkOROQCYR0zRAQAAAACAAACABAAAIAAAAA==eJxjYGBoYEAAWrDpAXDZR6r4qL2j9o7aS0d7AS7nEAE=AQAAAACAAACgAgAAcAAAAA==eJwz0jloZ9X1yVar/L/d/oQbdjd8poDY+/SmSdhzmTHaXfn2yu7nEjf7PS+Z7B6/WW6nvTjR/oLwH9v3Dux2shYp9pnSz21nOe/Y++KBr32n4GnbrkXT9vlyKdvfbl5rmxL3cNScUXMoMgcAJJI1TQ==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0001.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0001.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="920"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2156"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3068"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3084"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3100"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3116"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3132"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3148"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3164"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3600"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAnwIAAA==eJwNxn1MzHEcB3BRlIwehC4d6TlyrtUU93t/7kRJDxJTiVJOV5dYKQ85K86tkEwmDwldeQppU4vD72t6ssrlIW2mRiqr1CWTNZaH118vRbnf04YsCeexP5sU5X7c/z/9f9bY8gLuk1Vc+08lHVRLqavtGNcz5Epd2ftIWJrAjUhz8fz2IcphM7lL/r585O8wmmA/Vp7QzmH+l78jk7v/RB4bz1hkE3LS67jBXCWt8ybqGJ8EE2dX6uvKINN7U5EVpkHLtCySJfdwajcJ7343lPSp+ZxCOZdJ3Eax2yJUsv5lPLPNq4dOYAw7KyX135FQ/hDAh7vQ9po0qh/eCAtOjYCP+yh2DIgMlvJNjsFU4mGMSsxjRVEGTGmWcPb+CUwW/ww1Bmc4FSVThMGXgrsPYVuaMwWZp9La8dMYm3UES33SyUalwanrq/lliYEUs0AGS6EteyYexNgMLWfDEljTgA6tfwPQODuZ9hh5U+rjYsjynGjiSyI9EtZAfO4wPlvsIo22AoHLgviwg6tosFqFJdMELEDXi0WiXi5duoOFeFRDb6tAW0ESTR32pIs3H+JDkSN5RsRRoeg97LsPwFolp7gHekT3hvJ9cgmVBhSjcFzAmn914azYCsrGHSzD8y5MTdSwNEmiKp0LHc1tx60ri+h11GbqH/0NoXkGao/GUHXmKKJ1EXyBlw8dd6lFwzc79n3iHTocxHANl7POv1p8ajsDxQEFNWYKyV00AlGpA1mbhdDu8zPprWAPxr020KZoMyqriORvDC8hsf41OMN8tuVVK47VhuFNp5xNqroAm46rqBxIpOjFNoQVxmR0bSH57pXSnyghTZ+nhLBkDfUIbCn13lZ+eZkjaay/ImXEnmXnPMdwnRInU3ayf7fIIhk=AQAAAACAAACABAAAjAMAAA==eJxN0W9Q03UYAPCOSgSB4AChKw6EbRCzSFO77Pd9nsMlMBQneFJQ8idgNP8mgYOBsLhCz26mMueltMs4MMGow1NAaN8zcAPkULRDBZlghsgSrI68smEPt98L3n3ef9QXV8L7A5UsL78Uzx16AyJU9ey7paUY5YyBmXd72OEpHe71koPhrINVfq/DDKsEkkwL4K5Gh3UrQiDKthhelOiwNScAJpJlcOJ2Cf6Q5Qk7QlfCQHUJ6kL3g6LtekdD8x4e6r4PDJ8u6sh/uIensc+hpMtLqJBr+fOXKkF19YpwcLuWX1ZUwPHhaPb6j1oe1ayFePM29nhGyxPHdsKOe0ZWxIp5qj0XVlc0M6gq5oXjgdhkOc8kig24mxzNXd5Yk4WNBVbWbnoEKvINcgfZdLMcS0ebmOD7CjOSE8ea2C7ym2e2os/HGmbR91rmbN6lYZx8yCMKza0GoSAgls85rMVl65YAPBroDV+Zk9BGNogOzMvAsYVy2NI+BX7kcA85ZJH9c8pQER4Jf1cHs2DyyJJIuET+p/AjnJS7QfgHfZbH5OilbhBGvq+XoeFWFfuvNZaPk++Irr3th5MygDOP1mMduVe03ZqOHzp2w0jX7/ArWUoeIr+VWYz+fUWQL3Nn880Hc/GsjxJqU/otneTN5FPkjqcR+IVzgjnUa3gLWTPr8p9qH2yMo4PV63Ga/LPoT2ybcbTlBCSfn4RCsl109vUCHC4+CRdsD4Q5D5HbyGk3MnGjch+8mn3V8h45XXTwgTD892sJyEIU3J8cb3Z5uZsnLjEeBGfZOlxGloo+tVOFh40/wTPVE9BELiQ7j0zAuu5t2O1lg5aBTiGWPEP2vtYpHClPwynpadj72TWLkWwnl5OTpC9jpH4THBtS8BTydIXLceeew4jYOqhqS8Q5S0Tvt8ZjSKodFBnjoCevIq8lzybk4KjaAZfra4T5Vg8mY8P9Hni77RfLVrKJzMi5Nxfj0+16eMH8Ds8jPxEd7+eEyAXtAH8oUUUOES0fBuzvdkLtS/fgNbKN/C3ZPScNj8rcsXuhRpjvQEcCxqQ/gDtPBi2+5DVkO9na6It/LTNBqnot7yH/JvruommIuXgFMqVK7CMrRddcWIHGEW/8pn8MjpOPkU+S7dINeKArCL/cFCQ4yCXk2ZQgoawXMLX+WRxNuGUpImeT7WSP0x4Y8LABVi2P455kX9H/A/YaAD4=AQAAAACAAACgAgAAmAIAAA==eJwVxn0s1HEcB/AhtR3NUx5i5+kyTTfPCvN7fzybDjFSmkLYLcaGP7TK1mZSnjPPT3k6JEf/tOXh98XKbWYeosnTlkNxlq4ZjcVqvf56uYrH4V20zznk/sVo4hKWwqr+nznWmJHgqgY+/97FcWcwjag0sfmjG1c6kmjO6IRT+56D0DOFHlhscw0B7/md9XB6YTDFFbXXsHCBiFbz5VzKPSUTe5lRaqUhVIW7SDoNIidXW5y164bTfCKF6trhUYQ2bKXJZFxhjvzLI3yUVzh5fjoDaVotk8htqcJnjrsxrWT+BaZk+0EEC8NdOA8Gko7YDyyyC3tcAnX3SaDPaeHrfBLlOPshVjLGWx9KyGhKhAHUsfvHNiRo2eeEARus9LEJWcndIapRIXXFn9K6EnA3SwblTjyd78/CoZ4GFvISaNlFihLZRz7G5DplB/lD37Ke9amtSdNLAOPRDdYvNKZejyAoLqhwkOxLrll58HveieHFOKK0YrhUn3Ly9HiyEz9DiPMkv/kqhLz1EyE+18BmXlpR6bg5cnw32WyGEb3xv4nZsh2MxXE04FiK1ZoOROvGUl92M4TKIy647TZVutfhztY0P1AdSKknT1B51MDUSiGVzTggTbHJ6jMNaHooBQbaO6ga86IOy0b0tLRDVh5Fiwv9sNQ54OouxdBI9WvEDc3z+Se+ZJ9ZgolfjWxww4LeBnvDPnKLuYn0SFaQA+nDbVi3eFBudg+c2tqgkIZRVPYoFszV3OBJBF1zH0Jn7xdeb8WH/ozXAz+bWHTtRSo0CMX82hbzKdelvYmnkKu+Q3XkTDbG76DR2orlpmBad5uFwGyXm3IJJcXhJDLka/ySuyfJUrqQrm5m8VqmNGx6C8Xp39g/TZ4orQ==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0002.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0002.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="916"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2164"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3080"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3096"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3112"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3128"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3144"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3160"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3176"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3612"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAnQIAAA==eJwNz2lMznEAB3ARmpKzlic9yqOaHAmpJ8//+314SHTMHJUrnU/EM3dWokhCDZuJdErMVXqRWQ/9f45u1jOVYzMsNUuHlGOjJb37vP3EFqsrqxM1ktvhZMYWq6VhVw5b1Lyow+yRSVLL7zgmpGr5wXRSaut25YfkeCqvRUq92nQ8u32EKcJauqrzlkMGgjgofi49W2QrdLn9OCTdfxwdFiGmna6CUWEO+8lx7LirYWY3IK91YfiDfazqWY+JUip8P8Uz7BcQ4q+Va1X+zHMzRynsRFboN4xq0EgOukhR+9WIl0O+qJm6k3vMFtPwKAfLTs/i4Bc9K5QP4HHpKD5P3M20ojtYtWC1HJSwnJ3lSZg7ViF8je2Y6d4u7ddGiYPz7sFidComjd7BMqMLT6S34Fb+TL4KDWZH3wCUlgfx8MQWlh/qwybjOvncQk+ecXmI6u/2on/wNd44ecB1bbQYUXYFNm8KUPpVz01zbAgfc5oVOtL7gJb/QpUcZxcHZd5Ktimm0VCyVfa6rmLalC7s6nUQySnP0PM8Dhm7YoRfdwpipApk1cdwyckhpDvYs/WKkj5PnKlv82HJ3+1w7HRjwA1PNjTo5QG1NS0NVsz8PUPUPR6+1p/D9Qy9WPx9Dd5ebUTr3Wh+tGzEhm3zOSFrOlUdY7iifR3r+zfCYrIVZ98MZGnTXjl3oBPv7s1g2B8nke13HhUuxQi5HSvGmFlDjv2E7MtRPOZ8GUEpEr2KFXy6uR6rq2KYzQBklDbD/VQ4P6YlyhqbcjSZ5tOzSyXMiyJQ+KMcBZU7hM42W1rk04XMi5EMDPbGeFc/5pns+D4/GYlWB7hMqYNadRbhjQbmNB+XGzz340K8mibhLJzmOmJqzROUPN0p/gO+eiRAAQAAAACAAACABAAAlQMAAA==eJxN0H1MlAUcB3AzFeQAg9KhxJvQqiEn2Ghx3fP7ETwEd7y4dohY6RkqxElCTTiOlJk2SIcVqUSEmyu8DNFIlKQdz7NKEBngO3SGbbxIIMmbyDFI6Mu6Nv77/P0pTAql+otHhR3ih/zHGiV91nNHWNqUx0+W+5GnzZVKwvM49uEyqvFQUsqPJn5OfCjEuWtp3MvEtnRJML+UQkMHc/nXiv1CS282jU0auaFzoXAycT+V7DLyhf5C2rG4yDLTmCP/qfuYfM1F6k2RRvnqij0UmR4ntDUbZWGXgRKMFcKCN3PloWcT6SdDp5D5IFeWfgijlqQllPORSY5r9SSrwyrKcs+TH2ybEN5teYFay/Pklj3Lud3SL4iN8dwMO9X3C1Fw7RU916gcyFEcphq4C3aBh67u5aZLM8LPo77CnC/bfelWOu/utgiqmWZpzl/Br8B1Xz/Pn3sGCh6hr8lzPmD3adNTfLw4iYINcVwFl9k9cjiZ3zcdIv3GQRqH34Hfhq9dyebC2E/JWf2P+n8r4MelKWx+MYP67rdJs/A+eBAuLV3NIVPOFFQcIR+Dv4AD4fNnHThiXRm5DWu5Bhbtzrkbyz1r2sjD7S+ac7fdW2vT2LLdSte3VKvfgm/Aan21+kD/Bl7bVEdBITelAtgTDoFPtK7kpFYDaZxF+Vv4ZVgLnzdP0De/NRBv0fAZuNLuCEcVGwuW8Lqibprv6CEd9xUvY7/EcHU83Alv1YWr1z8tcuipSVpZ2yFp4Vj4GTjmAxd+bDtBXsejZC08bveCnR206f7f9OUv0Txp6CA9XAqfy/fn6sbV7HfvLl2ET8PecMKQipP7lZyRalVFw3q4fqdV1XQwiOOPerDv5k6pAX4D9oatp6bpgncTNYRFy11wJdwIB2Seo5sb8ev/Oivh63AkPNLmyIMBr7IQZqUBeBgOhyd1XqwZ0XBqhZNlFhbhR/CY1Z3LxoL5iaVdkg0+Bi+CF51pp6meAVr1e4z8qKqdFL3/Obz8E9rgs5xzDoscAyfC2bBPxG2qdFjP0ydvUQD8PTwF36ixkWZWz/kFJZbLcBwcBScmD5DmtsjR5fckEU6AI2H/O1W0r24h972nlUNhk91p46HUsNuHg50iOWOep1OPUO7oZl4bc40UaUcoBw6Et5vPkuZQFics7rVsm2fF3u/IT9ax69SAtAL2ht1gRVY+jbq6sHI0Vu7NzKcJOAj+FxsNCnM=AQAAAACAAACgAgAAnQIAAA==eJwV0v8v1HEcB/CdCju35ahRRqHSl8uOEOrzfJ0vUfmSNsusJuKHoqzmB+uHli9TcmTGcb50vhN1sjZbvnze3FptR0WUtKzz9TjfJwxTqt8ef8DDVaKBd9Yydzx5G53RQxgKLvhv5lxoTUIPAb6szWCjJoA6DEYYn6vHieoY6rPc4hZlJrD1jKNbNlNcid8bfnokhJ6Ie7isqkIWInSkH+lqLi5qlPlmWJHDW0fYWMxA2upPZhIfsLA6zHPXqf5lEMy5HdD1x1CS1AdXgrr4g6tBZNnjiFdQshsb9iRULXO2fmOsyXYvNbqfw/s9BqzEysj13gP4ZNagfTCSKF4OF8VvTp1wjQ5LHiFQquXHywPJ2zwaEpMS9invAOVo9iNJNs6KE8X0sS0O4l3TKOjyomq7UjxXVaE29zINDjTBzmyFUx4Kpw5FAyLb+vn0LRk5JWbj3VIpax2zoeYAbziFTbCzuSKaf5cCtUEPw7qU7Pe2QFBRge9lATRyqhdC6xmux+UCvV/V4o56mB9y86TauDokLD5j13ZYUbtVBOQJkyxUZUyK+zlQaCdx0f8Ixa/3YFSpQqSfF51ns1Bv6rjgoTPknKJHd7ee9045SfOBPLLXylmihZhED++iWq5nGWnbCD2qxOiLCbjp95GHpw67C8sQ+u0Y5esEpF3+ysluS0iU+gdN/Uu8o4M9tT3uQ9RGJYt1FxItpCGiYYq1BSxB87QCxUXjKJOISHp1AadrSjDXak2KS2ZUTB84XagNZTab0s+MTV5+05JaGnXwmK1mD4qM6HW4HOX8NPMx6LCVXIfs/DGIhjexJNiAqlcJ6whjavolJl+7t5zZnClVhu+m0gEBW2vYSUmXZ9DbWctSP6/8+5EHtcbA/gJYfDeWAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0003.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0003.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="928"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2148"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3060"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3076"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3092"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3108"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3124"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3140"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3156"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3592"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAApQIAAA==eJwNxn0s1HEcAGBEE0aYbtLOztu5vIyOQn6fj7eiGuNSmFEnnNeKnQ5nk7dZJGs1l9ut7eSs05UYO477faW8NKUVva1Udiq7tfNS18tuKs9fj6A7XDtZHUntFdWioDuc2rp262RqdgY4FjXUws8irGqIwsVnjZTuGxsXay8gU55DrUY1w4RSjBeJPSWNDaPTTEm4SX4cbOnaRWJlG1BB9Y3lZvNJNH8chgze4NVRiDxDGB5bEkNWmTcesS3FhN/tYHSog8DQcnSpaYI2RRwdlB+Pme7R4Mh0JePBejDadVEuJIcIA1RgbdUAjlYFeF/jg/XNC3D7pgc+Tz+JK+smYNoKQV2fiYMV65Ch4dFX9oXiJR81TK65kY3Nl/CKFQzs5FzCTmqDRvO7MJ2Rjw56G5xj7MRBmTu2Krn4yCsAe23yoGw+DHu/sPGphk+v8l0xRWCOwxtM0sNUQ35bPZSb8kjI2lF4LZ2DpTu5+MF2DlKzAtGhYw96rmzHuGUePt44AdZOdsjpScR7L87TMpMe3qjcMfsPi3QmtMOITzekKQUkU/yOGjB+Bg/nM8jxFQKjIBabhlxR5KaAclYpmnXGQ/S5PkjXCbDSv5ae3yYBqToEV956EVV2NFyvGwVGTCG5PGAR2T+9Du49fPzeKKSK7JNw1pOBkl+zFLOwGlNmIuDhYSNl6VeB1/420UJzA2XIQpQXswnvhpq6enwaXPuKyNfUca20cB2sqk6jnGxqFSOJGGHlgmyhJV30rwqt9wcBq/OjNvmBEIfjW2mFWYuWswOR28IhuyUJY2LjFHDfF5OA2kP0rU/LIJKdwv5RKV15NgafiJzxgNMg7a8vxn6RL5TQStpJlY86n3ZaJxHTJi0X5Qw/whvTaRtLNDAxXEL+AxeKLWU=AQAAAACAAACABAAAgAMAAA==eJxNxmtMU2cYAGCUQdXZ4bBgJzdjuMgYxgnMbJzzvmEdAip42w+lOgZIcIGwoJPSlowuFUx1G5tKNCiixBiRiQoYUHrOl0C7gg4tXVfsRpSJgrLBdCBRSWAv2fnR59dTOBIPO9sv8GuD9WjxjQSjUgbJO3R4UPsmFI4kwKRBi/qiXv7m2t0QUV+K363I5z+/o4Oobg1GTzxKdB+pBNlsCe7SfCg8qzDB0NYSNF2wCVkxlbDx1gEcbToEDovMbHKVsB/AAD97xfKaGg0b+ycPfENbeVtxKTsVmwRZmfPg5BYtOwYKePUiFI6/q2PjiV38Vnwfrk/o2L/Za3hD3Dpwn9Wz5t4Ac87Xa6B4VRk7Oq3A8lw5yKLT8Uf6QenjTZ+hISgGfM+PwRjdRF9AD8gtwxUro6D9mJKfexi9jf7k2l6c3jcfaj+6Lc59mH6Orl8ahe/1HeJH1yWxuR+gP6VPVS/Ce15VoPbZiJP0+9IVrZvxhFkAt3YEAujV0pO7C/DRYhvU9HVxH9Mn6H6OLs6vbSem7G2AO3v6xCV0ju6gP7wcjM7KT6FarWJz75fe4vcMnIV20DWmYjvdLj30ZTx+PytHbcsghHh8NCIDtZZlOLR9Gef5oGnA7N+8MS7mnqik59NX07vDFmHOlUYouZ7Meuhq6d9cMYP/T954kVuPpXQFvYHOv/DDv6oSkF11A9BH6SJdFRaB5XUqLGru7Eil6+nNLZ0dcS/fwe68GHwa+0D0fPqDQWA1DyEtPJWl0a3SZRY9vN6lxM1/qDCI/oqeQV9YZIWWrO3ocjpARm+l99P3PX8MysY92LntkrmAvpxuos/ud8O3CWl4d+Gw6P2VG47Q++hDb9eDasYH6ys2sEH6J9Izywf47PAIXN6QhKulB9EDpwAie/LwluEXiJRuozvufwG/LtViWYpccEk30uXz82HmjBoHdv8tvp6XD151anTTE+s+gCarP7raNrEd9Ev0fnpOcYhQkR6NoVbEbR6fsVjMdlsBBr9lA876/0PoPgn1HZPt5RhwghcWe/xwnIZrqM1Go/25WBev4S7SK+n+8jf4u+OB6DyVwRbQ7dKNtznxcG04Bm4AVNOr6Ar6jeEvxT998/BxTyeI9EH6MN10c7+o50rxdGGuUCH9PL339xTxxkAmioop0SldoBv7nwgu8MeBwC3spMf/A7ydDZs=AQAAAACAAACgAgAAmgIAAA==eJwVxnks1nEcB3Asqx5X7iQURmFtcgzb7/15ekTrYNm0poOOR60S4x+lY+Usc2x5iB5Tbo/zqanx8HzRhTnmSFGMhwePY5ijzdKj9frrddSlDT6pq5xT7DZargxj+Izo/9mRnL3E89TEt9/z2Czxp+Y5LUwtlsO5+Cr1GW9xy/ydsPIS0i3LWe6Vb4NcNRFAzw27uNSiHBbAs6NfCTWcMFTB0h+YkU2NO+xy5hD+U0C3y8JwOboUCtUl0quNxoaBJgYfhdGI602klX6WB5udohg/AfZY57Hq5QOk5c2Dacsky4s0pB6ZEIbaKohavanYWoyKgiKUZgbR98FaWOusc7n2wdScLUGIbECesMUnx8g0fFkRs8ZJS5L6+8DxrJJ9/bCbSi6moD1kBseHnUm62or6/NfQ8uJT2fYYKnnT3Ea3gNLahtEjU8jdTdzITfAOjasFbMbJhJx9hYj5M82S4rcReCgXiiol3GcsyNNrHAY5+Qj8cZiyxjWpc3WI40e4kO5TNWoHVuR2tgdJltKH0M1Cdt2DR7QUj/OSWab0UKFpqBi2xlM4ptpBm4J1JL3Pw75KA3JS65NGXjunR0ZkFaZL91y25a72uvTwxTRUIyXM3vovqsUZMBfMMd/+XsiYBDZlCnTojyJgTo0uu5eI8JuBRpEpBXXIuKCoBaxpGVOWWpuVJ8+jz2sFRXfKWULjFKoSRbCom2ejTfWoy5RA+/4EEvVr8Eykho92NqIkVXC4a0q7PKVc8KAUFr1G1HBChwmTm6CjXIZbqoTtL+nEm3MiuI0usJobYrifLkZs/jj4/Y9x4eQaumOzIIsLR8o1fXobW8El90Yh7pMOTTkYsCcT6RjLVaLQvIotBUphb5iBjw2L7B+Qhzn1AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0004.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0004.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="928"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2144"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3064"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3080"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3096"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3112"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3128"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3144"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3160"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3596"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAApQIAAA==eJwNxn0s1GEcAHBSCKnOS7Kcl5OXvKROuZPf93uIaDu1K2ErJJFzp8YQp52KvNR2Xlbek5fZOMRo5eWeJ1pS3rZeZGusuks5mrLWalL5/PVJbOarnmb7MXsy5ZjYzGfWr1o/HRkbBdcNOczrn2LMui7A2ak8Rr3kjLPyDGQ3xDHLggIYbpVhLjVlqgN5JGI1DNfoj0PFjZY0sHYF0pn7g/HRZ+mzhX4Y/xcMI+ZJeFHXG6UDNeBf6Ihr8wnYx34A+25fgY/bJJjf2AZHvEJJWFYAantzwN3Amgb3a8Bhr4ZJFZyjOl2VYDFdD50LCRjlZoHguxF179khL02AfyPZaGQlBnZdEKqtd6K04zTxaeJgvtkiJC/bUHnuMHx9Ioabyeep97ej8LZ6Ej4o43HOeBJOnvHErXd2IeeLPh7WiPD5SjgYskzQtUWInS8vkdpVLcy022L0b3taFaKAPqdmiGhNpIGWVQzXdxFulceh8BQPtjiHYN2UFb67K4dskzT0ZwcCn1MMsZNSrHl1lbw4kAolGXycorupvbsdmI88ho6hJFpE01Vf5lfA400sOlTkqry2H8NQpQUutUepJpQyFKVyoczUQNUjzcDy1iIivjYx0BMrQEeNC/1V2O03mjoKJrnJ1EMeRJreayCzNga7B6rJ5ZQAHM80Qx9WL3HXJmN3pgtISCthtSeg2klB1BUysqriYsMONyoaVKvyJP0w/EhCa1zqyfSNYdhkGIORY3q0QMbB4xIWfvpsQ1NEQSj354AOsaInzAX4Z6iUfG/REqMxc7ThuNP9XWLykFUJXKGUemyeJMKDCoh1isEcA086LdeCXhMLxWUi2qY0xnCRI+RdENISqT6W8ktJjcKWzrEnQLzkRtt4zSQ6LxRmPKX0P+NQLiY=AQAAAACAAACABAAAfQMAAA==eJxN0n9M1HUYwPHErXaJgXriAokz4BZ2DjDTqfd5nhMM7uJ+kKKYjutsBERb47Q74QTEpQHJIui0LJVhjdDKrjmRTr6fD5NiqHS0QSW/KmTjltgVQd0xNXtuu7b77/X3e+8v96+DV8c72Xs+B95VxUHMWALE/1yBeU1jbHTVLmi8VI6bL2iZnB8CX9MBXK/5sGtpST30NtrR83aHJJNqoaDPhjPdT/DyKDtsMNlwc0I+tyzWwdo0G/5irYWB8ys3sQm7iDhtA528jl2cOSDOdWrht5YAy4itECc+ioSUO4kwyRwiPfcdlv7velikOSicpTvcCe3PwBuPVApXa53UyGLhZE2lyDHPS177CDvTUimyX5bjd3YlfFOqx+fIP4U8llOAfwwZ4YuOaQh6jnyBfLrZgddbjFAzH8WCvkauJh/NLMb83UpofvYGD1pPPk42lClxOtvNqlZuEUaySetmB8me7gi8mfMVOPfp8AZ5nHycfHk2Ew1nfbBqzSQErQ/5zmEz+hfdh2WuOnW4LdMGDBSOwJNikAd9l6wg/+CR47GzDfCZfKv4kVxN/pycPNELov8BKDdkYbgNf8bglJSKeGsYjGF+5ZwKKxYwjG596Uq4//YqEFuSccGj4/wfMiMvJK+7fxtKEkchLjdbpJNfJ8eSF8qKwFYbh+WyTHwszLD9Ehy15aOXfw9a8hHyLXLW0CC03SvBwVGpS0P+lHyK/EHGNRjeacA9a6a4kzxKfpHcpHgfrq+VYV/V86I5zE/LlrCBoacwbaMGtSGnklPT29kVZylGt/fBXFo7c5NXkB8ummKFKdU4eUIpyUL2kvf6/GyJ3YKrt/p4GTmarCL7526yxJoYjDYaxGyYe04m8WWHlTgQCdhBXk72kPM+0fPd6mKsKbkKOvIechV5b72eL7c5sHCmQDKH/BrZ9W0Sd8UXYM+bc/xiyFfJ1p5OqVglxzKHSWwjF5Gt5Airizt76Wm3GheTG8kD5Ky23/mmbgNePsVBR95I/poco7jHj6nNqGk+JC0lN5B3kmc7hnlTaybWmwI8QH6X/BbZn9fAp6wRuK8/V/xF9pL3k+PlD3hSz23YUqjGOHIKWUO270oV/jMKnPhYgv/9K7mrTS0CGSq0rDgiSWQ/eQfZY0kWRmpo1s7zfrKJbCFHBka45/FeeCjxBRFF7g/5P7kOEdI=AQAAAACAAACgAgAAoAIAAA==eJwVz31MDHAcx3EnRDU5SsnKUgydRsoqfp/vpSkt16rRYVgUWw/meTc3cpiQh9bTaRV6uKJyjcVY3f0SMi2UhLOyO64Hl7tK5cgi/Pf+67W9/USNCM4YZstkE2iI10G3Mfd/c1+lK9mtFqDD2o8xVRhpTJNhNN+ET9kuapszzgbFtnAPTKSk+X2sIPSh9otBQheELSyjVMkldl7UeUbNEnd+4jXuzlQVsB7PnEwYTRCT38ETCDmvQv27rUTJF7Ey7zdTp2ynRaJ0hK9o1hpvhFPwrHiIbAv4q6wFdLnRDYfFRr4204EsTQqoTb0w/VxBns73ISguxoeiMDKsaoWdaz9rWRlBz743Y5+6S6vzD6TyxAqkDF7j221cqN5FiospPfzs6QlELcnHp+pu+PfOo9WBejgqixD1finl6AXUPPyWiVNF5HDqD2rah7ReCz2p7lwbdo6V8IQAO6KB05BW9vEQkx7jsgpcyvkMh65fGBKM4XprPlyl06hmREjrPJ4we/N0KtnkSIVvBNxaOYUOx/SjtaGcn3o9CgvLgrrRxBXJWsRFVWH5WwNyazWYbZ5ARHUeqnwasCV0LsUeqmWZm58iUjWHcipn8CM+LVCu+Qbv7lv8UWw7wp3y4KD4ytV7C+EfWQZZkR7i12nYFjGCF7Ic1Mn34NzumXRXdoulv9oP+RN7Mi525ArDZXzM70aJSzUfiLoDb+EVPH5o5tJEOSQe2Zg6/Z9jFSIprgPRqdmQyOtZ9HIrToaUMaNnGwsYHMJ4o5BP6vWFpbwJ7l63eapbNo4/P4ZVEgtvOhP57+UA4hfr0fPjKHvpVgGbsmwsSAvSXErXYHOsiu2wL607tOEBsoKE/EjnPRaTfBXJ5moevukoRmVh0Pla+F+uOjjgAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0005.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0005.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="932"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2156"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3072"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3088"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3104"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3120"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3136"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3152"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3168"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3604"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAApwIAAA==eJwN0n8s1HEYwHHRqo1uw/JzJVK50y2F5tf3ee7chpa0WSvVOPl1kps6haJc0S7VTCp0pEg1TozLqPP9PGrLjsIfpajY7DCrK7GyotT99/r3vb0VDcH8y7NhnCi3EBUNwZzFvMXU+8oIQusC7u1CBp4pkuDYUDFnMm/FscIc3FCXxM1KNPCiMR/VJOC0siB2cCkG/9KP0Cv1TiSrmYfTXGt3SsJRihY9gUFXBQyVpuOqr2K8/agLPlZsQnGsHMu3j8L6iTxwLEhBuX4QDk3uZVMpYVgXUQ3lv9yof3EMbuxwgIzeZIoyqyGVewoVfam4q/gfaNa740TVBgzp2YxpphB8vCiHjZ9FGP0gEPv709hSsABtlXZ4bcGDjN1NENlXCvevptGR/I9c+88p8HJMRqHPKXBOl+GlDlfMdX8AKk8lWt2OBGlWK8SZFJi3rZC9sakEbWcAzox6U3OCFG5eMIBz+DEqodP8zPQ8iIcT0atSzfvZ78PdunVobj7ED+jyMVblD+WC1bxemYM3GktYxsUBgz5Rgt6TPvTrcluYUWUEO/VxarmXympdxsFFIcfalk6WEGvpd3bEAt8R9nJPCq6o2gLt7weYbq0cDU5lbJxp2USdGF/n+pLunz0736AHz2+Z9KGmi3V0NMFdKzlGPXOjgFUCXExwwHfqEIovE+HvZS/4fiCQZLGbEU3XWXq4HWXpliHbbxvFvS5llVI1aPcrSXhuivV7SuFwmxxNPjLyVVXAiTuOOPwlk0I1LXDSXwizzxW0xrYBbPpK2cq2AEr1UsGfORE9bDYwj+wRbvx+JkXUzLN4rjXM8gDGLcVQdc8PQ0m9E1qeoSoS8LdkQfCpMIcC65L4OYmG5RVJaHqomJ80b6UXr4xsp3UBP7yQQf8BkoZBEg==AQAAAACAAACABAAAggMAAA==eJxNxn9MlHUcB3CNMzgJ2zwDwSRqHl6k+eOCQ7nn80GwaaJAUbmBgGY0DAzGecfRHXAQiWduLuCIbCwaRszl5q8hyD3P1zUtREGtYS4KQqEA8UpZAwS23mz8ca+/Xnef6MkTeV0ytn/M588FUFexgXalFvHkmEu6cvAQ2QcLuWnpi+7gKiedqbJw3GCHPFNUSbvrzBzyYZTytiObjq8wc3qJSRlv1NI768z8+ganogn+Rmq+ZeakDZVUG7jSOPWXRdhCssmafVEa3mYVhgwt8cnl1CYXiajTDVJzqoE+fdYmvvo2zJ0Xoac+tV00qlrlGy3PUNNhu6gJDFbuXKiW+gvsov2JQXnupt597LZNbDmj4YgGpi+OJjDjerwOT2pI45y9BfSHbYTexN/Df8OlTCv3XDeTJdxXMuIjeAv+gTOLH4XtoBZPpzL3e3g7XnBWywt9Hkqv3osVJtyAr8WHgx9T8dXbFHdhGw/gZXg8nlEQyUNxS/gfWx9lzt+DD2sT2X4liO+kBBm9b0lj9tGr+DtPj3II98Mb8NVL/NkQdZrKW7cKHb4Gr8Cf3uyiP9/Q8LXGeNbg/XgHnvLTECWpE3hPz8+UgCfj+3A6quLF06lsKil3e9/65RSZpmJ5o2tAKcHzcQNuMrZR9FMLeaZju/gIN+LTeMGqQulus45rJpjL5l+NZ579V7p06gBvSuygZLwNj8F9VSsorNfOpe+Hyur5V+ABsy9Q74lMTn9+TPHDf8f34A+6FpF+XyCvN+8UHq/vvCoplxUt/0gSJ+Ji/rrX8pX04izudlymcK87LpkUm9HKJ3L3y6Xz/xrvPr5dKT2YxtdGxpWbXg8oeyCHFGp4dm2S8Pf6Z//dUl6ZXczm+zF8DI/ALfjkjQDhs4pZX++mCVyFb8Qdu4OE7pddXDtaLpfjq3EnPnDfR2iXRfL+rgmlHw/Hs/A1498r6pxHlOhMFuG4P56Eh04vFZ0PW6ksxMgr8S7cgVdc3CHqRidpZrNMc6/GF8TIpG5JFZplKnaud8i+eCB+Es/pjhV9nYNUv25CycN/xV346NQC8UlGDcW/lSz+xivxrfhYkU6cUy2iyl6J534KP4JXHT4gdHtD6eW4H6ga34S/hLs67OL80HKKHkqRa/Em3A8vrs8UuVvGpFzdY8WOl+D5eKs1ULxblyfR54miDY/GJfx/NJAPFw==AQAAAACAAACgAgAAnAIAAA==eJwVxn0s1GEAB3DSUrqIK6x2tiRtOJ2iFzzf5xyj8rLmLbTklmppNVGjzeoqWuRlc+6GhnHm7RjNbLbze1CSl6JZGrM5N2+HE5p5m5fW56/PeZdOeGb9JU4pe2iPG8FIUMH/M1elLTW7aIxfa/PYrPSnbXP7MGmohrNKSn/yt8mS2BSCy/H04clZUuzbyukngmmmZT/JqlCyYLPTdOxtA4mP1bHBx3yqlkRgMFePjmhCG11zMKZUIYwXSeuTSiDQbRD/8iia716ImKkfXKPCj97bTkP+RjFb0glo7oATEronWUjpAap4kQNF7zSu+znShI1+6ApLEe17hV5lC2jY0pKgES/qKptBX98M5ykT0sUADtlrZeyJlSXlvUqE6sMMm/LQQzOsgj1/Ej76/XRTsoqMliKcqLOgTrvm1KjoGzlCrajgDo+muuxxbg48mpY/Df1oJXOw20H9x1zYSOaYLIFDZEgdhMMTKGhug5VhD9fUCtQ5tyPK15qGJjWTvIguBFbyqbz2EHvm3A+l1wocpmpYR+gQAo4pwJMtsOBYOdxmy2D7QIuwcSnEwkWU28jxXOqDcLkZNS6sIuKWQASsmlKN9VHGH3iJrrRxfE9Rs1z/Gtg3ZOHUHwOzWY4D5/EOpUZafBb1EGsdw1ZsPo4LrQh9NIbN3QoiSfMijsLfoJOWzP6gMYpFTUgW1bPguAzcWpeiOHyR9Vi4o9ZfgphPWkSMFnkvnU1FYokcyQoZJ7N7j6cXaknT2E3u/sQbmPSasyq1mKx3x2BnpY4FTtxG9pANxlUGpl52hEfYKLkbq4PhUo4m/auGZFYocSZHw6k0ZUTh20rypqs47y9ZZEVsyg6LuryVJq/JlKGaneu8gZ2EdDK8Ns/+ASXBPBs=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0006.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0006.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="924"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2160"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3080"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3096"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3112"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3128"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3144"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3160"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3176"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3612"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAogIAAA==eJwNxnks1nEYAPDSq9mY5nWLV1ivXK2DRH7PIyLLMr2EVs7J8aKSMyrv0ByVY22Od0qOWSLSiOT9Po1EmFaTmk2p920huaKGKJ+/PpG1DrLeNCfOMiUDI2sduM3LNk+vBvvBQukqN/JbjFeynHH8TTYnnzHH8YxkFFSFcXPOOdBdn44SUuekroeZ/5oXrtPSkfxqHXKtWIQkrrkrPCiUEm0aQUU5CzSUo/BxpxAzc0bgwT1TfBvgh5MLayBQTYT2zLPYmrQAZzpFrOCAHeYJ26F3fictrr+HUZP9YO4dTrbzJ+CDdBi+NITjJ9Vh8A3ciztKDNFscjseU4jw9eJpUOGroUXdSWx6d4lVrE3Dx0ZjDFoxoXKPQngmrAX/+ki69UTJqaVvAYzrQvFXdiInVvfCQTNdLP0zyAmi0/BUvyP0uC9zPKskvLNxgyVuneVmAxGrYsxJVNbOFfv0gX6zmGwy3FjNhAJSKoKx5bmUpV5wwaEUTbTntzLr6RhsSdkDsaye8RsjUC4sZPLSdLYmO4hVulYk6pLLsmM7obsjlsYqOlhb20Oo3BKMHp0GZLtdHVeD+DgqcaTAIktc2TCFeT87chXtRpQXsygXNbrYsAEJ+6wpYKiAlR6VgNQ3jsoGptnYlDEULgWjYu449arEw00dLVRMXCZzuzy4XmgFG0/jSBF/Df5KbzNeqgONuh+Cr6mWpLX6grlsK+HqQ2KpPGCWaQw4yQxdw7DPzJOqLXmsCfTQ7XMyhS8DE3k6Q0hbPA3+9GGaXBb73uBERTPAyFtI2rkvWZcBjxnyxSSRdLOlHjHLjzmP9jVmlKv5g8XMGaHRXTf6ZqBP0Y/OgX2CM/0LEJC6npj5W2kTOvJI6f4uWm8uY1qjlaxpKoL+A+xtQPI=AQAAAACAAACABAAAiwMAAA==eJxNxn1Qk3UcAPATlNNuRMElx3ETB551dRF3yZ3MPd+vrZAcTvRwHJa8NAUqR27cNl5ERXkJhmEleXUbxJ2hVGZmyh9tz+9H06sM27iSbHBicWNTE19KhqxofZ+7/cHnr0954/NgGLkmeA424FNl/wjFQ1po/akOH+16RNhwvQV+SapFV89RsSZog8g5C4Zjs9jqLXuged6Mvq/r2fETK6D0CQtqqzpZcq9OKJ21YMz+Jrblrk7Emlq8ebsN1Bs/UnUFrXxxfDHYY/zCr/Y6Pr0oLDRFnoUOXQMvN7eoxhOUUHJuL5/b9LmY8V4S+HY3cn1RGsvytgrzhY1cYVKxByUp4rxpL+/oXc0mlY8z+Ww9/9SfiJZgMbz2tgZP0vfT9fSlp7ajddwGlX8HQHotvYr+8yUL1ud3gVz1r2qEfpBup+c178T7vBqOVvzIpPvoDvp/o6tQWPYYKNrX8wi9kJ5GN2eMg112D766nIsmuiP6A6WrsLUiAytMPpDeQt9Fz7+jxFdvZGKtwafU0rfTdZU+pZidiReqUrAneJW56N/RP6Qr4iLQ3jMMI+pcvpJuo3vpX/TmgLxfgXMxL+BnC24v7AbPaClaLw5DX/Q19KITpyHfZsR3lvhd26K30lfEDIDst23Y1j3FUunx9Bb6orNN0F2dgO0yDY+jv0/voGf0B8RTsU/j7mwBH34SEL+kv0G3rlzC+i69iUPBIWiM3k3/tj0sPnTtQ0Noq8ijN9IjbU7x+nA5Zpvusb/oE/S1dO+aTFFxORmTx7T8z+iX06vrv2f3NycgrF2HJvo0fT39lc44Hu5/Cc05Tlh4pyKB//FxIZ5MPCSK9N/p3fQ1r8+xnAEltqWFWBZdSe+gu48dZz9khkF9tYAvfN/4cm48exosDetQeg3dTA8dLuBG6014N+QE6Sb6EemsjGvcIRjs3SfO0PPpF+nnz+fyuw2jYNTPsEH6NN1A19xazHe8aAPZBwVcegk9nu6QPcNNugrBMS2g9Leiv6Y3cPXWPGFsxg3SMXr5sQP8ySuxQqIXRenP0VPpPZ167r4iVyl23mHSx+jp9A2pKdx5uM4VUGh5Hv0BfYruv5HKzS/vYZGlagzQDfR5+tSFIh6c/IaNnfGAn36LPkHfMVjFPbt8LLvsjEu6l55O77+9iVdOeFj6wCSTXhX9kdllfHOSgx2K28ila+jN9P8B3GU4DQ==AQAAAACAAACgAgAAngIAAA==eJwVxn0s1GEAB3DvCrFj3sXCqLwkw7zc830sq63pjKZ5adkJbV7GmjZmrbxbShpHl8M48nad1D+4/B4im6YMSRo6b3k5wrCa5qX1+evj6foe/sU75HzGMXqFU5i6Jvp/5l5pQfV81DHxW4X9xiu0Z00DixvNcGmIpaMmB2QrUBenfeNpovUKqQrq4lbnBPQRb5gUSyuZQM+BTufJSXzMPHuRyqOfFfHgaa9C1OdHG2wlaKmV4mVpGJ380g5b/T0idgynPRWtiFKMc3kHgdQ59QkGtyWse8Gadlzxh3PoEivIPUbIWTHmZUvwWrakPr5KGFVWI+TbOVquVKcfd76SwBRXapBzhPbxbc7B/gxVFI0iZr+exXnrUbqZi4jWFRY0NgIFa4Vd0zyGDGcgWDvCsMNzpFxehprUlIYNKUhY2jp2NUxo+ZE2ay5UYdR3G9LkZpbXvQhZvgiWr1VMfkcCr+AGZFQrETj2ANFXd/EpoxyKrAQU3TakbzJaSOFIGrIG9OmikxHLnivBrHgJ9eYythnSAUfeU/R3bTDzbSE470LUqinR7zFEzOYZ/saUwdTNmNDkaewfScml+wHEyW0SdJHH7E+oo8qjA+ker5hAWICbf2JRFf6LRfW7423bRZTuKZEzbsV39o/GYzMR5Ilibl2VhIelMmLen8d1pgpxUHWKNaRbkQvf+VjIbGOzZZGo8NFFq3CDRXq5QNtPRGyCFjASGRYg0Tzkt0MMz7gWrvODYcD14D4ieVfOGRhr9ZgQTfZsQo3YKY0CekOb2IzWDXgHHfJtjFXsrkEE2mJreoqTf0KnpJEM3DrJkrZqcM8lga+THcoS5TPExGuQ738QzQwtVFx+yg/SzZyYRl0dy0rNBsnJ5NrXltk/Uiw5zg==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0007.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0007.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="924"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2144"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3072"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3088"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3104"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3120"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3136"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3152"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3168"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3604"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAoQIAAA==eJwNxnss1AEcAPDkNGRWpGScdImTEhd5/b5f7aY0uQmL/BEnulwqj1KoKEq7Hsva0ukhjyzRlU3Tw+/7dS2naBRp/eHRZmXLa5TWFpPPXx9NbZDYnh8qeJ0qRE1tkLB4cfFs6noH8qVnhM9/tJhXHIaDPSXCyLgHDhbmorQqRZgKK4U39QVYxLZChTKQ4v+pcJ5/h+iqV7Py7gycFJ62ph5Q88BCNXzrKQPNaQ2aTkpR7jMFPlVuaG+1B4+V22Kf03H467cX4/ZbYc3jeKqb8Ebf7k8gTDpz4scPUNKigt6BVF5mZgukGQZ9+UE8514OqiIBt9c6oTHxPex+m4Z63ANXDH3gcykZhy7mU6hDM/T2bEH/MRlLqtXw4FczVIqHeTSuTaxInwaLvGSs4nnx4csoDLZwQI8TEtIu5KFlwFZw0w+L0cYT+GLXFXq4RCfKrRAVOjk7lUe0FsyaQDFwhO94VtKXS2/AwjIJE7rMubRAhtEZdvh91IWPxYRj4Q4ZLCFHjl0VhnPGMpqu+0nWXavQRebNfs+01GJ3GxRRR1l+9jt1uu2AxKYkHPFU8qbsW5B5zx77xzI4pNQAWQo5TBk1bLm8FszfXydJ0zZOW58Nc9NeXNf4mlxzvgpDNRmsT5iklZ2horMyBTtkkVztJSEDOGL4cC6nzgLFRIZB8vMs7pqIJXuhmEYbQvnGOBBHb2SHy2+p1UlCznZafiRtofRrFyjrXxpOqddyjMaMX8xIMbMvkBt+ePC7V2rQ1Su4fcNmNlinke1Pa+5es4Kf33Vld9U1KjF7Qh37D7Gr9zpyNLVRozEdTf7ZVJYbxN3sjgEyHam7j/LtvvPQf7+Q8m1yeKdUSRH7AsnGI4Irexw5aLVe9A0eo6s3U/g/up46mQ==AQAAAACAAACABAAAgAMAAA==eJxNxn1MlHUcAPBiBpSHdnAhii9MISFoI7Pw8Hl+X+5ALzjiZeGarBcwjqgIzXmAcEDC6ZgvDbHlYjBkgFMpl5lTznu+PwwINDughARaVEPlxotwurG8gL7P9rDx+evz3ewW9uv1aXFAVwRjpQOiKmcP+3RbIVii/O0tdcfY5/H5oD3pjZsaK9i4pxkMjly8LUSxGz0H4KHhOAYPFIlxP5jh7HQp6jcXS4GfFYCtZDN2xq3F8IqDkNp0hCW+c09o/Sefm6p2sEtXPNnGiUI+MtQgLlRuZyuHi/jcU1pp5lQ4a1pn4SklvujUXBUdaRY+yhim3n9gN+4r5t/WB2OQZQ2aLx/kx3fXSCtnC9DUUMBL5tWgTdvP2t+PBwud0TvorXlvwxc5tUy1bpTJP6E887f9MFjYwNq6nEIG/S+62O0U7kZmwszpStb89U2UP05voff+sQki28OY6BPD++hAF+jY38bcfz8DKzAW7Evumnoe9u57HdoD7rBHym/Q4zaEQFl9LOR8/+P1pfe7tAbWV0aAq24Q1fSN9El6VvUoKyp+wGYu7uDZ9Hy6i26/YBFXZL8E1SYGzXQf5X0xLrH23Y/BNtrBBpVfo3stC2RBwxYoy1oveSu30n8PDWIp5gx41DeG9+hJ9Cf06UZP5tAFQJ6XkU/Qe5SHsSqMfm8DnHFGQyh9u/KwAgl9L6aD221jEXQ1fYGe5fsTak9+AtoOs5RBj6Zn0p2u89jemQJXbS58qPwy/T+P3Tin9YGMiiTuXnLzRz688IVeFpAaDfIt9FX02Vgd1z+tgsiEViY/hv4qPbExmb8ypIEr6eWSUbmdfvdQFH8c4AHluY9x8YfoMf6zOHe7hY0FJnNGn1d+5lw473I0i1PdAtTTufLJnbncuu0b8eXkNjZFr6GH0kuWl3H/4GqxpnenJN+LfoDeY93DX5zQikc+nEQHPYF+jJ5wazVPyg4RfJsSuZF+yxQiqOlW12rer7LixFc6OEy/ozxt1Vs8ouVnTP73FyY/nJ5EX3jjAz6UPY5dZ2vt8ofp1+hbd8XzzuIRNEkjuPgs+haNN39z1znUDBi4/FS6H31o3ob9TR68KsUAw0verX+ChlYdv6D7ky3+PF08uowvd6fzw6XlgkBX0evoR/E+nmow8ufMPSj/S/qz9K360+h3U8Pz1ur5a3Q1fS/9f1KnMHY=AQAAAACAAACgAgAApgIAAA==eJwVxn0s1HEcB/ByjDCGNcpTzVYbpYfzkIfv+6ts15MTRamW9WA9bFL4A61i5Sk9ydOdhzx0R07KaVo4v48u1Vilho3K3IXoASdtWqFar79eG9do4Z8zw9yT/qL98AAGQgr+nzyLHLi5z2L0zX7FL6WEt30xwsjEXXgojvC3dvPMEGQK500x/JTjOCsJbhY+66X8is1LlnOniKTmbvzD5fssJvojid2seXVGIk4kj2NFuTdPSqjFuqoqvDgRwsMT2tG73MBa5kO5r1crlHX9gvX7QD6nLQamymiPbBnPstmOnsFRapVMQ3ujEsWyEZStseTrD07BV1mCiRYHXrjLghfzV0wX6siz1WZ8KOO3cPWkHX9Up4PPNwVdkBnxhxFXUSF8pkFNExpuqmCSoke61X1kF/yBv0khzqjuYdXppdzMR80ietVY1m3Lm7daUEymBhajBohzVOSk7EJlZAHEg99oX8w5SF3yYGKmQ9CsDU7t7UNYbB6k5zQsbO0sUjcr2MjKt8zbMI15rQ0tGvPEZPVzOLvVU+zyPJzvTIFYOkmd1l5QSbbgQKMOke+KAw2rk3H2dj4SC9OENJdsxItVTP1hn3BcfwmiLiuquRfEfr44gIXvdbRTfwjXeuwxpJigKC8PmPgVMKfgYXRHhQeUihYCH0COjcdqhcfPrAJ273zCSjX5gqWtcZsdE1Fu3yLmqrMOaA+roUHjSHgHLwQ62X6lHXFHcStaJMTPfcLqvNdM77CSmmfKIZG7slv2cdTZ+pEljm9jz/OTqcH8k9DXLEJ/CuhRWQUdd81EqqxI6Nw/RvEaJWpWkFCv/QJTv1w0lGZTd3s1hpqycPFHG8l7F6Nj6BrkG56SxKVDGFeXwz1ERhVv5NSoaEFs+hK6nj9M/wBu1UBhAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0008.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0008.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="900"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2096"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3024"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3040"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3056"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3072"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3088"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3104"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3120"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3556"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAkQIAAA==eJwV0W0s1AEcwPGS1Sp54Twcm6PJQx22Mtxd/r/f5cb0ghe20JKnhZw7L1h3wnbMNaU21Jqnw3l4QyTNmuH/+3GWWeJeiLWVZju1QrPMvJHq37vv68+3eEAtvq1KEC6ZLVg8oBakFqXm+cUFuOhWI3w40OP9ei2uO62Caycc1y0mVPQWCLvaBnAMVmMtewodOhVlHqbhEe9fbezzZZ1tD+4Jo9N3cvL52Ks28FnrgZc/ivCm0gdB447H7cGoqtDinywFnpHrQdGVhK4AfzSOZFN8fwg+kG1D6W4gW2od8HNOD49LC1nn2y7EaLbhybMCTM1QwbnwFOxyyvFTtwWqPCrwmkIH6pBGyFs2YudKHb2LLYdmkxqdHMrnI4PBe34GRmZLOMqSRP0bm2C25eLYVAdVliXie7MM473GKXKrFMfMEWCgQfIaLkJXWBO5WqvpUIzBXj8lp0+7RKthEhwTBo46vUypcU2QF5aLNaeiec2yBSf6vVD/NJ2HXpzFG+kXwHo3lZuNJ7FF3UKdTUH8RbEE+h0lD6kGKMd6HT5GGznZtke3hdEEyQqzDtO4c2Z/6lGfL0q23Mae4nOdCj5bTBzbWyD+0jZQZb2Wvzmt4uZOODsWF+iKW424eqDn2loH7c/pqbG0ECVDfijbJskQA7uS+GuAP5eMZEN8hZb/ZinYU66nTKUPo8ad3ezBfDTaRt5rPSQ94qDIYJLPz9DwbAnOx5ZTi0nNyxyKcSGNlL9s5LaVOljttpBkzskKHaVkqMgjPIV7nHJW+7aLlzXbJD3iW9MuocEwSbMTBvzeWg2/xRi2+ymxjAZBsuWNsCZQe42DZM5vzBH0eqoDTGWJvGSW/X8E9o1NqrTl8j+npz8FAQAAAACAAACABAAAbgMAAA==eJxN0n9M1HUcx3FwfC/Bw11n2OhwLUB+lG2Apxbc9/OWwKGT2GAJGXgoKYqTCe0OOvFiet5dnBultrFwU6ClroKy+JHC9/OuDURc0W02MhmO1TI2zJU2jhW0Xrd92fjv8cf7j/f2ej59JEtsj1ohbv3jomNKt9qZ7RQXzjfS8UG7Fp3UKtacdlLjnVx5znZIrDrnIKW9RSYu/qzmmZ20rswnf/TEa+vvNND4cIY80BYvi7e4aLEwRgt2bZVTBU1kKfMJ9sSruGHciIq2eFGyxcXzhTHqWNdWgRvu3PCDVvShUfxGx/nXv16SlXcDts++aWLzkSyZH7VC4jeuU7q1C9lOefF8I/sH7eoTSa0Sv7F/wUQLc15hMW8nDxwZ8ooE2DDzGl283S1889NCgTtgP7zWfZQ81b3iqdCELeyT8Gp44IydOq3t4vXATRl2B/wG/P5wIr09kCc21BGfgU/Bz8Pm+o/Evh1msgdyae0yrxyZE5ueK6AG97iI1f0WTIZY2tOxiyL9FUMqbIcP+yqGNhsV6i1WqUaZlGH36U6NHBXDORE0E9rGKfCI7mRxQmtJf5HWTeaQCT4NW+DdN+q1r9JqKeagFMfgL+HV8L37Vm2vo5nMX+RrU7rXwP2lPUNZu9+kccusbIMz4SBsSgrm/GGxUPrlnTwBP9C933NPhsqiaWPGy1QN/w1b4ZSeOL7kyqaau/1iuX3Fz3JmXwH90urR/LqnYEeUkVM+yaCGK4/kkp1w0ePr8uoHD4W5pIhfXeZHuancbCwR7tZsCvsd3c882M8Z06fEtWvXRdiZ8Nfwn64G/qncLwyrDmhLjoAPvVLOVSerROrYQ1kD79M944rjlRPRYuxxIYcdDd+CsTsHBvLkC3VEZ2EPnA6jDe6ytsvSwE3RB38Ml8Nx7qPsre6VjaGJobB9sANGe9x1u1u+Oz8tw+6EW2Dfgon/m/NKdMteeBFGt5wcOSpHcyL499A2StSN3WmjUeH+YpUPK5Nik+5q2GaI5cqOXXzWV2Fb8rewYWROoj1uco9LBd4Mu2B0K/fuMHNlIJdNcBW8B65NDg5id067vJM+TQoOYnfG7vReaY8NnfD3llnRrPs7+N/7VhUtMVpSp3XPfp6vum/Uq1fTavnJg1I6dJvhBHFCRbeMbnm97gT4f28fEhY=AQAAAACAAACgAgAApAIAAA==eJwVxn1MzHEcB/BdUVSkmtUyT8NtyijyULvv+xtZtDB5WJthRbEuT3nYWX+0i1vpdMilbipOVxdyqc3Dcff7tOucjVTytLPS9aC426UokeVhXn+9li+xIEb5jYXJ/qIxxQ77puL/p6UlIdxnlQhvxlwYr4rnZqcH+tw1CNel8pdBE2wo1huz16TxjFmf2NU4o/C5ezMvCGhmysoS2uyzgHecNbC0vT0kuejHB21yGJwDcP6M4PNn3odIq8X78njevaINPiEu1hyZwJ9+f4bDhk7BHrWGV6fpkTlUQbs9g7kpOBnnM/tprdOBCZkehepe+HX+wrBoHNfaNAhJ9uJ1IwF83Rwr83VP4Td2+POy1yIauzWJn0hyoa2xmnLbRzHIimCwOMlwoAxRiTrIyh2Ibc/BroQRvJCp8Tg7Hfn7pvMG2U2W13oU2VZf3if2J3m3Ch80H3EjuJa+bKnHwoALaDK6yXY2EYHuY0gRO9D/4xRrCdXDU3cZc3OizYV5ZuzcVsX2+FY+Pr7xIYqiA+hkxz2WJC2F1F1LG3acwqgsHvalg1Q7LMbK7e/Z/r09cK9WmRQ2EyuoLMEilUnQma6zK3FGdrFfL0isSvY11pt8I55ISjxz2Ud3DS2zbMVvqYK9HXNRll8ybqdWmJWZ/fBSVTHrnqkkHarAyfB0iZd8K2UYOllQlE0SM7GLpoe4BMWhLvaIxOSh1VL2ETlY7mmhzjlAWaYq6OeRcMfihHf0JdwtO0etjdXoupePnBEzaV6LYO0qhCayieLnWIVP9dcQtqmUrrdpqEH3CIcUU0ml7qVJcEJxuEGwGN2IfjeZh/adIW1wLeyvZvCI9vvUI/bH84NBPMHfRA9kN4XFgdN4sbqIWmRqWi/+g44wTzpd7qB/7iRL2w==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0009.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0009.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="56"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="924"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="2140"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3064"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3080"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3096"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3112"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3128"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3144"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="3160"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3596"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAACgAgAAoQIAAA==eJwNxn0s1HEYAHAnStrUJG+z06Juzlst2ZHf97Fs3soNrVmvd5eX4+IPRnkrqlND3K4XbqKFo9Fk6RZr7nlaXsvLrWkqozc3yyUK0Yjl89dHrg3Q9+QGccJLBSDXBnAb12+cegf6mYd5PvduSQE514NhwqDkJmcEMFFwEfi157m54JvsVVMeFJINVxUiwrhVMazR4uGSOnsKqZ5nWVxrZ8I5GQnEZUzJa2F9J5Ngu8kahh12gK7aFUqbDkK3uzc0Wyey9BERNE8JYOiFDOdkThAj50HHPJ8a+e0sqeway1hNpFtt5kFP+34z10YZLCgzOYWNGAbcHKByeYDjp+RCTH8g6wr9w1l4ZsGd9SLM5M1ys2cBai8IKFbTzqmP9zGnVgV1uaiR/2mQNbhIwC9sFhsGvSBHbQtmu23o4a9o+LDixpyXrKio7ShEJ6oxM+4terjwYXHNk65qxGimqGN3RWmkeWPCsWlXplqUgHEujHqs0lmpvR0Yv2SQ4FAxu6LyZOvP08iYfpn9qypDi+wAGg31Z9+yhWS38hKPbKrgmqSpNLAygZoDtpjSGw9TCUGkDb2P6r/OYJufQLJnw3jCGMW8YiV0z/cj7vmajZY/vanqUQeOV7hRuFCHw05yNJQnk2WdDOsXdPhAnwyBu3Q4YvAhvx9uUPxkBPffkNJYUS7Tn3qNEd2JVAPHMG9vJYoLORJpnYnHs8FO+Wesqoyn6bJazjBDaJ2TCpHLwIbaRGTQCsFRrWQhY6lUYlXOJo3l7IxjBiXohNg7msPC48OoxrSTFuXu7LvUhL7jEmoRaZlUGYHvfdKgRuUKE/whTJnxhKLkKFClbabyADVT3I6Fpsfb6HSsO+Zv8YGRAhNa1NuScOswi/RXoWyfhP4DvwZEOQ==AQAAAACAAACABAAAfAMAAA==eJxNxn1M1GUcAHBy4loSdwh6R8GM4eY7DSjk5e75CiyQ7qhpIcaJt4WYhhJHgMgdB4JoCptTg8qXVsH5Agpl1Ol1z/NlnOsYCOoZqdBpb1YGoWYORpB9f9vP7T5/fS5fj2YDv8xm/qd3wESpVTvLr5YdHS+DsIJ+vnplA2vwlsDUVpO4uSeRnTKWwJwn94vjIz2adEcpsKRscbl3iuvTy6Gu0sytm1LFQH8FVM24oB39LkT4qS3QO3M3K1yVrM13l6F2IJQZC5ewfvMONOhXOR+OaZi30YwvaFTCOMq1XcEWXHcrVeT8sYtHnq/An0MmuWL8DRG+rBzv7BvSKCz7xRFbKfrHaNjeTUVii6EEjV4F/O09yKqPpoH0B/IbVGvggBrZzjovq6cfpNfSU3sKYCzAzZquuDQp9Ad0hcelsdgMMPJFG3t6hVtIv0NX0DvqI+DaX7ns9Q6Gn9N/pL9GD2W1rG9OOLwTCzBPfhF93X9uVq/JgsHWHmaQ76EX3r/NQts2Qt2aVmeR/Bb6imeGWcJeHTiDfhAv0hPpDvpXh4+zV+bPho3qNLTT9fR8+qdxySISFwMzJUCzfKBHxZvEx0FvwfNl51gM/Rg9mm5xvCvMmnI4vDWPm+Ufk+6nE/oNuWBIGxUmuo5upHdP/sNb+lTwwZAOL9Ft9Cb6htUK7Oz2sGx1PEi309fSDz1KxomqADjQ1snep4/TD9H1za9i9FAInMip4Tr5rfRmUzzaLs6AaeU94fvwtH+FfbidWWMz8Vn6OfnFvy7Hiqs256P+JJBeIv/+zG34e4SJB4chk36THkRvvG7FuT+18zeVi7n0EPpmut/2PCxd+i2v/OS2eIJupVfQI+LC0KU8z7+vzEDpvfRBenXXpGgZuSEW9qWA79u6FmGxOgKVbg9rlR9MX383FofVceiczk98/LGp/MRvYubjhb4laH54RUh30a10b9410eKZFqerU1D6Z/Qz9NDIk/zDhDDc/nUG+L44o4MPf5SHN+A3ZvL5+OYmvja4Ct/bE6X1/a0vX+LLMreh3SLEXfpSuoM+qy7LOW95FOY2JiHfleVU0dfT3845yxwnJsQCyIQtdKf85xb4w6Q9Druj77HHd9FrslWw8GomHvmzRruTvoi+mx54NhBeLliJl/Z1CqX8i/RA+yAzpAdie0A8PiW/g/4/HHUy3g==AQAAAACAAACgAgAAogIAAA==eJwVxn1MDGAcB/BE642suaRkTMPWWSHdrvR8n9apMW5eNpsydlEUlsVEzIziSC+rruKm0J3a3dWy1tDL86OWl5WXGLoovZxSV94qyhWZz1+fNSsbEJI+wvxOTOOBygzzZs3/k3/BAu4im4E3v6z4rY/k9YP2sAyXQaqL4a3zpti3MEcsksfyhIWfmVZxXwx0K/ll9xaWXlJAShdf/iG1gsXu6aHHd525fpcaT6L6sd4s5XdGHqL6+g3Yy8N46XQnjC597OezcJ7RYMbz2h6xVhLIA8OrUDNSTP1+Ei5VxOLoZB8pXr1ALRmwuLQHT906oBz8ixbfQhyO6IddiQff9rSWbTsyhFH7eTzvrwOVXbSiVf4dJYfKKLXGAlOaBl6VVvKUp+HHxkLofbogIqS4VNaJlJxcWK7ZWEOfHTfbdKz+piPiM6ewJc6dzgRtgOv4C4z9MdHOJdfQO/c8NPIvFNXojyrjamSPdeHca+/QFSHRuDJfg4qEq2LIehBns03MszFV3EtUYUo7h3THvFlAeyh6TxqpM3cn8mWOMKiGaXnuOjz63BSa8NiC/Nkz2RnFfpEzoUVzORPBk+1ix6fnrGi3RNwc/SqW9kyIqy3JzGSpEB0FOjLsjYOkJqu+NWuAxndrIE6XimIxgHsn4tA7eJqChnSI/xgBpamS3l+wsbVrtuLAYDUV82eiLvAcDt/OILleS/JIA77tmxTaQgvJJrohSawXzinD2NQ0haE2Nb3UG3Fe7chV03WU7uSG4z4u/BRroNhqo/AoduBxlwqoyJpHyd0/4WtyooCOLopPmsvfeivq2vy/wFUq46tevxMJwyac9VTyqGVSygp2R1L5Fp55K4iit+uFbT/jbs1ONEuXS+o+L+5pLxMxy7voHwA9UJg=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAAMwEAAA==eJwt0QdOAlAQAFFERXrv0qRJkybl/jfzb3wkm53sJPMDZDOZTD7z/4ldxbHbOPYQx57h2Gsc+4BjX/FHmpc0FRPcMsEDEzw1wSsTvDfBFxP8TJNN85qmgAu+R9ze0hRxkYvbe5oSLnFxy6Up4zKX8x0quMLl9Wq45jcr6NVxnSvqNXCDK+k1cZMre6uFW1xVr4M7/p+aXhd3ubpeD/e4hl4f97mmtwZ4wLX1PnHsoVv0RnjEdfXGeMz19CZ4wvW9NcVTbqj3hWPP3KI3x3NupLfAC26st8RLbuKtFV5xM71vHHvtFr0N3nBzvS3ecgu9Hd5xS2/t8Z5b6/3g2Ae36B3xkdvonfCJ2+qd8ZnbeeuCL9xB7xfHvrpF74Zv3FHvju/cSe+BH9zZW0/85P4A4N4eUQ==AQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0010.vtp
+++ b/Data/PVD/paraview/dualSphereAnimation/dualSphereAnimation_P01T0010.vtp
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="50"           NumberOfVerts="0"            NumberOfLines="0"            NumberOfStrips="0"            NumberOfPolys="96"          >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" offset="0"           />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" offset="820"         />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" NumberOfComponents="3" format="appended" offset="1980"        />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2812"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2828"        />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2844"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2860"        />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2876"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="2892"        />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" offset="2908"        />
+        <DataArray type="Int32" Name="offsets" format="appended" offset="3336"        />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAABYAgAAVAIAAA==eJwV0F1IU2EYwPEw0MBxQEEvilxYQ1tWoi7c9H2fuYGZlIKIH5Rzic6YjGDh+lDwkIO5jDGT2rJBaHrhlsj8AE3P+4hgzKl4k0WRUM0kZFAOGbXR7HT3v/3/2keVwsqDUiK/2wPto0oitiA2vl0L0LNJ3eRd1Aj3e9WwvWkloXAObPdYIGu4hfxU2+jyeBfwyJEhbTGrj1fBXzwoeTSSiVpPhHaSycVW3U2sCPO0jczTZ6ttcMl6SG0nT8BXdxaolmRgCKlgItZMT+3J4eqYAoJBA4srOUg1SeBxVIqBRS+9vOqgr/oNaMdO4cduhJ7f0kO2ixfy06rhii8Dwq8bhQ1fF9SYC+kTLkWYNllgcNzOjA83Fqb1ajizk4u/+/ylAXOASvgO/OSZY7OzXvrySDNUvDmORckcxHTp8J5XYZNTDn8S2fRXnQK1NTKA0AC7pZHgbV+C3snPw4Z1B3OV8XSo1oTlnghrIpOl4iM0xKvwxdLBgn0kE0QTdCMnPNUW0889FlQMtwj7ahu716vG3U2rsBPOweW1ACtI6ha2osb/j6xy1cFG+g0QU3IoMUmwPyoF6Z4cr40pcCVooMolGYpW6I81syLrIRMN8Zs7C8vDPGsl80y0xS99/sV1c4Cl8h1wrHejZEavxtM7ueDlUsiMyYLOcTs9OtFIRCusNxeycy6eXEyrxkpfBg5iJ/m+G2EXtvR4fd1B3WU8e15rAqNGAuI7M+fnwX6dAjQ1MiShAfqBV8ENpxwTiWwmGkJBModxXTp+9MzRqVkvE23xHyU+J9U=AQAAAACAAACABAAAUgMAAA==eJxN0l9MW3UUB3D2h002UjVrigOzYJNhzNKMsRDWpD2/ERE0XdgDdNYpwsMMSukVBdlKNTEiMTRmJiay+eC6QIIwW1Yt1jB7zxkQ42I04IYrNZjh7NwykW1xL2Z183uTS9K3z8N5OPl+v/+49tD6TTY63xxUvy2Xuu/tD1P6QK+KXbFy9Y0BqnmmR3VdGuSHitbR01qPmosO8B17h37nbK9aXCjgbzc6+ddvguqJYr/b0VTJfRJS1WEn7dtt07WhkPopOkBL9g437gX3lNjoJNzLtmK/XtFUSSEJSWXYyY7dNjfuZdW1h3OFNp5uDsoPy6X6v/vDvHigV6JXrFR1Y4DxjwQuDdKGonVcp/XIaxGLev1qhM7n6tQrcDc8C/+ea1QFe+dpdDZDV+H7VfM0Arck29WPRzL0/ctx14vwPOxujbuSfp96b6tO2yPfseH34RK4tbJcPaIdo8sX3GL4YdNvltVSoKRCZc651LuwBqfhtH2I7h5vU5boDP1s2go/PzpBnnCXOlyYTflMvwG/XTBO++4dUhPJJX4HroHj8Jmz/XSu1qpkS72MwSmY4b9zp/jTXeXqqb01ahU+afo5xxwHGnzqseoENcAabIOntUXu6WtXM/6gPms6Cp8+mOJ4olF94VjhiOkYXJw8yn96LarzY49sMB2Ar6V3is/TTw+Ga9Sa78NTTW1S6Byjy4FJMrwJXoDHW7rk9EiMvFOavubD8B/ZQ3L80U/o9t2bnIU/hFfgW/VW+UspOmn3iOEV08hcHteO8S8X3KoN3g4vwF/7ffLBVp3REU3Cg3AZ/FKyXeaOZLiiNZ5a8w4Ye5AHVfM8Npthw9gDj8OvRiyC/fB0rk4Md5lG5qzXWkXfUq/yHSoYZ/QlseQS5bt5dILRqXQUZl1e0y3wRfsQYwOyLTrD+X6rrJY7SyoE+5FuGFuSRXhz8ihd91oE+asi+BqM/NXwwRR9lWiUUccKGf4S/hxGp9Td1y4X/UF3vj2OOeps8ElpdYKfNb0DvpU7RSd2lQs2I7fzjMwVMucTdo8yvGoaHSn0xeiIDH8E34TRqfpsJMaBKc1teBh+Ek42tanNzjFeDkwy9qDWw2n4enqn8nr6+b/hGsnCL8DYkvwP1143aw==AQAAAACAAABYAgAAXQIAAA==eJwVxnlI02EcB2AtyBNjaks6INSE8mhaak3fz2stMk1FvCqCsaFQLZDUIIrARbNwKpa5YRJbbJLHlCIJBP191VLKSWHSQlOYpq7SWRa2cnlEz19PXFQ/pNqfbP/VDfQqxjCWUf//FKMP4b4JnnjvmsdK0wne83UTZpzNiDQr+UjQKvue4oXdh4v4xZ2fWaOsS/gylckrRcNMa9JTpm8Yn7jVwYrk05Rl2MJ112qgG5pD+vEIrvozjOkGA87KjvCTtIAOt51ljCXxGLUDVqtDkKqj+WKqgGqXkYoDRdy//DLMVQ5SqwQUZLUh2jaF+s4eBDo3kGbRoS2yF2dkYp5T2slq8wdwqimI32/1oSuRw9An/UD4bAv15YwiNVgHf/UCbV9SQIi/DYOHHS8kr5l4muCW12FbdCDjlyawsm5ix24ksYjoD+AzIgr19kSj5CnKJO2UqajAud9KNOYtkmUpAvG546xQPg1nYk23ZrCbVZr02FvTLZi7jUwn62K1c4+F5Jda9iPFi/wkA8n6zTfZrLOZDvRnY02lYTbXPO0bKYY465BgqnJgNdbNcsMTqcplxPmSO0xl1dCg1cHWQh4yjbeWnrntguC9A+kVefSpwUD52dXgW58I+qE5ipO+QsD1N4KfegHlyrcYrailsNkWFCba8K5ukO62+iBN+RELI1Y6XdopyMcnkZlgoHSLjkpDJ7EnVkQxtinKFfvyBvlyz4O8RZRoorjl1y4qlbTjecBR3vftArEZEVrMMr6sKqP1dZOg6DvIHxVI6a+8jsq0wXxi455g9LDTP7tlJNQ=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAACABAAALwEAAA==eJwt0QduwlAQAFHTTMdgOgFMaKGFcv/Lxas8pNWO/kizAqpJkrSS/0/sAY49wbFXOPYOxz7j2A8cu4qb5VTK6ZvgsQlemuDCBJ9M8N0Ef0xFO+7Uymnjtu8Rb/VyOrjDxVujnC7ucvGWltPDPS51p4/7XEsvw5nfrK03xEOuozfCI66rl+Oc67k1xmNuoDfFU/9PpjfDM26oN8dzbqS3wAsud2uJl9xE7wvHXnmL3hqvuZneBm+4ud4Wb7mFWwUuuJXeN4698xa9Pd5za70DPnAbvSM+clu3TvjE7fR+cOyzt+hd8IXb613xlTvo3fCNO7p1x3furPeLYz+8Re+Jn9xF74Vf3FXvjd/cza0P/nAPvRqOXfUWvTquc0+9Bm5wL70Up9zbrSZucn/DQBshAQAAAACAAACAAQAAugAAAA==eJwNwwFEA0AAAMBvWZZSlrIppRgRMSIiYsSIiIiIGDEiIiIiRkTEiBgRMWJERIyIiIgYESMiRkTEiLrjWkMIbbbbabc99pl0wCFHTDnqmOOmnXDSKaedMeOsWeecd8FFl1x2xVVzrpl33Q033XLbHXfds+C+Bx56ZNFjTyx56pnnlr2w4qVXXntj1VvvvPfBR598tuaLr9Z9890PG3765bc/Nv31z0hLCFFjdthl3F4T9jvosP/Vgyuc
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereAnimation4.pvd
+++ b/Data/PVD/paraview/dualSphereAnimation4.pvd
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<VTKFile type="Collection" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <Collection>
+    <DataSet timestep="0" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0000.vtp"/>
+    <DataSet timestep="0" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0000.vtp"/>
+    <DataSet timestep="1" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0001.vtp"/>
+    <DataSet timestep="1" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0001.vtp"/>
+    <DataSet timestep="2" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0002.vtp"/>
+    <DataSet timestep="2" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0002.vtp"/>
+    <DataSet timestep="3" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0003.vtp"/>
+    <DataSet timestep="3" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0003.vtp"/>
+    <DataSet timestep="4" group="" part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0004.vtp"/>
+    <DataSet timestep="4" group="" part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0004.vtp"/>
+  </Collection>
+</VTKFile>

--- a/Data/PVD/paraview/dualSphereNoTime.pvd
+++ b/Data/PVD/paraview/dualSphereNoTime.pvd
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!-- This file is not from paraview. -->
+<VTKFile type="Collection" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <Collection>
+    <DataSet part="0" file="dualSphereAnimation/dualSphereAnimation_P00T0001.vtp"/>
+    <DataSet part="1" file="dualSphereAnimation/dualSphereAnimation_P01T0001.vtp"/>
+  </Collection>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation.pvd
+++ b/Data/PVD/paraview/singleSphereAnimation.pvd
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<VTKFile type="Collection" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <Collection>
+    <DataSet timestep="0" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0000.vtp"/>
+    <DataSet timestep="1" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0001.vtp"/>
+    <DataSet timestep="2" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0002.vtp"/>
+    <DataSet timestep="3" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0003.vtp"/>
+    <DataSet timestep="4" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0004.vtp"/>
+    <DataSet timestep="5" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0005.vtp"/>
+    <DataSet timestep="6" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0006.vtp"/>
+    <DataSet timestep="7" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0007.vtp"/>
+    <DataSet timestep="8" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0008.vtp"/>
+    <DataSet timestep="9" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0009.vtp"/>
+    <DataSet timestep="10" group="source93" part="0" file="singleSphereAnimation/singleSphereAnimation_source93T0010.vtp"/>
+  </Collection>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0000.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0000.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996952"        RangeMax="1.0000000308"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="816"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996232"        RangeMax="1.0000000324"         offset="1064"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BBCBE08" NumberOfComponents="3" format="appended" RangeMin="0.49999998476"        RangeMax="0.50000001541"        offset="2052"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2860"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2876"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2892"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2908"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2924"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2940"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2956"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3420"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAUAIAAA==eJw10t1LU3EYB3DLXqC9aN7UlubLTC/S3Bxd5A7nd9dwbkYSpV2MTMuLILpStxzzQrro2IrSm6Ybyggqo7kDhpzj+YVOVjjUGWTKCgoXRV1k5ugFWb/ngfP8AR++PN9vXp56/TTxM8B9jYZP7c36iWtngz+9lLN92+4k44ccpHyunTMeKSEdBi+pjglcfKONbyr2kNeVAnev5Zry46ydnHni5vaPlNF4Ns0b32Vto9+v0pe37NxiysmBOboU5re0ER7M8gM68i9RSMAsFk4Qf42VgOldryW1PfUEzLdGDRlc0BMw504+5AtcIR7MiVjp9HY2gObhFb+Uy8+gGZr/KAklDjRjokYWy7xotlRp5CGTB834xAcpfsGO5pv1bqlhJ41mUVGT7G5uRPP8o3FF4MbQ9AkF1OLUo7kSsdBnBjOauk0z7e2qQ/PKAx292apFM39rRPk8HETz4u+AXBFLRcG07csoyV/VIpgDpQ7a0TAkgmkyeenAjRcimLurPPTT1JQI5lSbna5Z7otgXs6llfcHK0QwC1nOS82NMpjnWM473JgCZh/LaXXqKZjLLOdzg5mCqWE5vV11FMxOltPXqqVg7mI5vwwHFTDXJ/GfaL5a9kt5ezJodsfxn2j+jeE/0Qwew3+iGX6K/0Tz7hr+E81Z1nsy5UQzzHrf1EbQNLHe/yQK0TzKevfVWNHsY70f76lHc5X1fntBj+Y8613nCqEJ++yPhqfVfYYWc5K6z8HZdlndZ3JSkNV9Xq8UZHWfM4/dsrrP3tWsBOZ/jyJwWw==AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAA0gIAAA==eJxN009I02Ecx/FDYmIEJoPUXFn2V6lbBtWeX5QEdihImfNfzLUstalrkKaITc2iXJaHtCI62EGqmRtoTdrzQ3ew3JSVF0MvHlbQFOyQBl76fJ89P/jdXoef8maf5zuebGUlw5Mmx+sWNbI0ZvrTZmNkdzAYXFiyCg+OVPO/cwHxzQC8ORcIktvwzY8lKyd/x9+utdmEP+F/XhqeFN/kpjnZA1vUZGxqVvbpnLu6S9k608O+3VOEU6TL35cqC40T7FpRmGmugSs365QvOWH2pCDps+an8ECGWYmmB1jv9nmu9+BMhnLe0M08HWdVva/4QqYTYy5GDVadQ4fbWcaQUaGGKXin9E/DB7Y7tVyhnl/wHtgOD05yVtHnUHxoeAZXwhVwzqyXrTotyiM07IVXYA88taOF8eYspRcNIWnqaciPBD3rTtHQBPdKb0vr5kc7s0VDKnwMjsK1b8f53VaLaCB3SP9Omubri/WiIS6twE0lY/xkzCwa9L58w82HKjNFT7HOZxZucfPatNiIXCadbzCqd4rdYqM8+LZ0Q2GZal/2M2ogX4et8L+PN9UDsSlWhAbN2bDXW6p29fvYYzSMwJ0w7eWLZ6rvXO2MGkZhL0y/j4KGyrXpIDWQq6SPoKG12M21Hs0ONNQu+3k1GvTeQEN+bIpTAzkPviB7evp9nBrI92Hajhr8rnbukT2j0nWJvTg16J2c2EilhhSd7djI3WpRbWi4Kk2/VQwbbSzWq7SRZtquDhudjpnVh2ioh0/BtNfFxEYqNZDfSNfgDR8fc4kGO1wgHUm8YdEwq3M88Z5FwwpshOm+XuENl/c5RMPLxNtW/fAhvOG40yIaDur8FW842JwlGmYT71ml7fbjxjttUbERuUszbnzLTI/YiJwkXYEbn2+c4HRfelfhxkM5YU73rlm790h6gPfRjcNhmLZ7gRs/Z+jm1PAcLpT+D3k9U84=AQAAAACAAAAAAwAASwIAAA==eJw90t1LU3EYB3DLXqDpqhHUXtqaW3aRXUhU5Dn9LrvJGUqUxZBKh3fR1RRzrAvporPNQXlVcyFRVNrOzgGpnfkrdHLaC74F2QYJhkhhF5k52kLW73ng9PwBH748329V1f97p/7S899F29mdxQpxbXWR87N+bm1zhYwczBD71DJnMkdIp7FMjkk6PrWSP3fBUiJpp44Pt61N/GxVycWXS9zux09oqugmps9eLvJjlb6/p3Iz8zkOzMisjWzUOAmY9j1B8lcNEzAtwmvib5AJmH2FMXKiRyJgfjIJJJANETCnTpnIXpeVgDkqRd9sFvU8mIcWKolKtQfN4ekbinA4g6YkC4p8pIxmW72gPHSU0EyNdiipKyqaHwvFRNOWG02DIat0tKQx5+VndVTg7Wj6hEHa2BxCc+FpnI4ZRTRr10Xa2x1D0/MgSO+0B9Cs3rDQ1SEzmtf+6JN1UqsIJrfLQ3O/n0tgDtgytLPpgAymw1GmA7fPyGBury/Rr+OnZTDHr6o032iQwbxZcdMv+0ckMPexnNdb0gqYl1jOIG+nYPaznCebQxTMOZYzZhQpmDqWs687RsHsYjl97QEK5jaW89uQmYJZiOM/k2B+mKskqnZ40PSm8J9oliX8J5qPjuI/0Yy+wn+iOZjHf6I5yXrPzecwZ5T1vl7jRNPBei+pYTStrHdfg4xmP+v9eI+E5iLr/X42hOY0673WZUUT9nlXtL3V9jk841e0fQYmlxVtn7m4Lqnt85ZTl9T2OfFiSdH22bvoVcD8B4iYm9A=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0001.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0001.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999997241"        RangeMax="1.0000000351"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="864"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.9999999657"         RangeMax="1.0000000335"         offset="1112"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BC44538" NumberOfComponents="3" format="appended" RangeMin="0.49999998621"        RangeMax="0.50000001753"        offset="2176"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3028"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3044"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3060"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3076"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3092"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3108"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3124"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3588"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAdgIAAA==eJw1z/8v1HEcwHHZkkSFK/2gTZcvZXLL6nPC5/VON/nSKMrN1pE0LTKrVVuy8u0ije1yu3Ya84MmolldMdW93tRK30x1ckP5MrT1jVLT+YX2fm09/4DH9nRy+l8xL9KUQXeLK0x5nWMPk7xY9kEzpPdqWKjPPvb6tA0iXKZBfpDFqly/Q3DXCbkqMZVZvEdhvbkdy9cGsI7hVgjvU/FGqwUylJFg33CSN0wugw8OPZnlzw2gkhRMmE/mX8D7R4lMmCWp42BozmbC7Pa0gaRIY8J00zZCgRTEhNk/sh0KFR1kZhRorRsrr5H512PWqlAryWz7GoBuIUfJ9JB24fnDhWQW7wnFlkt5ZI4MueC8s5pMjb3GaozrJbPaLw3VOxLIbJr+iW8zJ+h9VVgQb8/zJbOoMYIX1oeSqb2h4ikJ/mTOTK7g92IW6X3JYcTmU1fJdF6qwSqTqyxMm30zn4gyy8KsyD/GK1NssjAjJi7y5ulvsjCjRvP52NwnWZjKoXCe1NMqC7M67iXed4mUhblcV4yf47xRmG5ea7gq+CYKc9y8lw+PT6Iwt95N50OZiyjM46YDfL92FoVZm7OJr5a6UJimp+34+E48CjOy/4dVo68gU76ix1h3Hy7MlY5O7GxN5sIc1PXhbY9cLszo8B58Jek4vV824a2cYC7MxHdKLDJ0kan+UyrHJhvI1M17QsmIH5lldQlQE3+EzKSQLJjaXUBmx5tDMFOWS6atzR8GLuwk0zvZIhvrn5G5RZ0JmrBoMg1fFsCotdP7xzPbWN/ZdWReb4hmgYOBZFpCJGZ1+JI5sODOfv+ao/em0loYi9GT+Q9QrGcWAQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAACwMAAA==eJxN0VtIVFEUxvGKLgo1Q5ZaJxA0tRIvTVdH5uxtyajk0EuKl8oUwqggMkkri7AbWRKoRA8JIWliSZAy2tScvZXsYmmNTlGTlxwnFJT0wSgjydbabOG8/R7Ww59vbWsLJq6GdaQ86hznoxOW5JxM4a/VLq3OTsgNcFe8lcV3tKrojPF0lv87VsObCPNK1vMslKEHaL1zMC9LeM+CYfVfagLDe2/IE5L31E4Ks3Kp3vcDjLSrK4DSA2tpnTQBWxJiaL/DRF2hpUSVfg/+OL2Z7qjYTkfMBuaWHgbHKgp9oITQwNsLObpB2j7uJuXHPSQ0bK/wdem7LeXq2NG/ouGO9Cnw8eIhtT4wTTQc0/ld01Ji9p2mPdDwWtoN3ljlT7qjS6kXGjZJY9vTmin1qpYjGhj4CjgI/Le9TjUcCaLY8AtslDaUFbGRuiHRYwR7wdjj19zJCr5sFQ3+0riVL3KSBbVn0z5oGAEHg3Efr3WadZ7IFQ3D4JfgUdyq383q7btEj97ao0qmmJaIBq6ziY6yM/szRAP6rHT1rJnPZTYR7NH7Xlw+//HQRXqhAT0Jxq0sywp4zYZPBBvm7QMv3pfKt9Q6CG4yb+wp1Pz5c+tF8aOTYKd0aeUM60zq1nCfC2BNOrErlTvmwhluQsAMnAjuVYr4oVcpDBvQB8FvwQEZZ3hggI1hA1oBD4JfJGXx320mhg3oGWlby2ruOPxTwwZ0s3TZjUbGPzgZNlwEt4Nxn93Tftx0ZQ3HniRp3OeyK4KnN8bzbmjQ25a/iQ/UWvg3aEgDD4I94JmyVVxJDufY8Ae8Foxbrfe8ZTfHvAwbwsAV0g0TiVpxzaxosINLwNg29emulrLCJhq+g5PB2Bb92KktN5Zw3CRKGntcznZt5aHzouGjNO6T42nQLG/2i4ZMsArGtsi+Aq0oJJhjQ7TOGR2XSNU5j2jQ+6bqJslNcaJB79gXc+RzczrHf8VIY9ut2kW01ZrNh6Bh3v3gvGs+ErNTFQ250tiWXlhDDMoiHgYNmWAjGHv+A/yFOPU=AQAAAACAAAAAAwAAbAIAAA==eJw9z9tL02EYwHExs1oZulnZRRAWUSoNNH5T2/uQDXEGGjpcF+kwwkCytMNFJmhmeYBJ5lpZKJbHaR4wU/PwPmmCkSZqnp3lYRplMehkkwjjfS76/gEf+Do5/e9lhmYDdNfksiX5L+iILIQEnRfEve6Fw7sGYOCSDoJdE4C1LIJxcxL4tH9SGyPGoVlhgJ1FSsx2r4TWGV8IHGzEch4ABu9ONun1BUttmWzc4QLCzO5zB6V0j8xXq1p41zlIZmZMPBRYlsns9tCB5DlFpky/D1KlajKHrE0szVMCYRpSJ7r25HmQ+dstmXuqysisW6nkMr8FMt2kdn7t9B8ybxxv4DXpX8m0TmfzVec2MjWTcm7ShpGZv3eKq47003vVcgoOx58hc6t/NTYmFZOZUd6BaSUNZOofNWL0iQoy7bYcfBaaTua6Q4GWFBmZzutyNJpz1cIcnSzHBbUXE2bORRvmReuYMIMX/qJl+TwTpvqDHee+xzFhek+/wMgeXybMfG04PnftVAtzY6wTftSauDBl8juo9NmPwpwv6sOZ+bMozENN73E6Ph2Fec48jCf1ySjMh4lPcLsUhMI09yqxq/4NF+bRoQtcc2sTCpPlumDYtgdkbnGosO3pCJkTsRFY67ZCZkhgCPZLs2Tab+/A6sRaMiNGynhGQRAKU/XTmYVFuZMZu3qXZVofk5lV3M8Kw+fIjPRbZEvH1shsfTvG7FkrZI7WVbCx6y1kKqICmKkklMyDqnmm8e+h94LPqWDSnyJz9ko9DF41k3m/tAcOTFSR2ezXCtxRTObYmhF+fLtMZtXN3TAX6kLmP0YyfKE=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0002.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0002.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999997485"        RangeMax="1.0000000343"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="856"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996862"        RangeMax="1.0000000329"         offset="1104"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BBE23E8" NumberOfComponents="3" format="appended" RangeMin="0.49999998742"        RangeMax="0.50000001715"        offset="2176"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3024"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3040"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3056"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3072"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3088"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3104"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3120"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3584"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAcAIAAA==eJw1z/8v1HEcwPHL5vpMN4s6rNhE7tD6Ysu38n5/fDssUsy3CstRWNKVYk1kEksbaiFr0fpCy5cxu1N0r9dat5ZSoTZrainjVmmW0Up+aO/X1vMPeGxPheJ/Fbh+823+x/cT//UgVU7LW+Ct4xq5y+gsp2ocZMfn0fLEcjV/Z1TLf+3j5aqFV+aBKKVsHg2Sn66zQtbYMG+ftpO3WhkmhafxybfXeLe1EC0rjUx7T5KFORIyxfbviSPTQafkz9pPk6kqs+PNKefI9Cv4zRYS9WQaeweZTu1L5mVVDJsJNZGpUIcCxq4i82NjPdTsDSNTWuyEqPJcMt0O9UGYpZBMvWMbvNCkkLmkPgFn593JfOmigJqiLjKvj7wGZb2J3oOaNmBBiUTmqHsw1h73JPPDT45rGrzJPB++BfXbncl80q/AnN3TXJgHv16Cz2VFZM6HKvHM7AoTpu1ADGaoGBdme6YBfxzRc2Eq50pwrjKfC3M+PRO1hgQuTLZRiz05bmSmrO2H9x33mTBNEbbY5m8PwjSEROPijSQQpq6lEH1vloMwc12KsS7+Agjz4qN0jK49BsJUTXlhgo0fCLMZ+mC0y2wWZkbyMFiuPCYzssIJO5dUKMyAkJ0ovfFGYVpngnHcdRsKc2hIg70+rijMqZZl6DZ9IzM4shoCK0tBmGDZAXkdNijMbM8qiEuOILOZt8LQXD6ZuYF3QBd1ksyJ7KvQejSNzGxlOvjf8kBhTlq+m3dF9JAZ4GZidyWJzAMeEk88HEtmx2pPXldXROaSxps3+JeSuWnMiT/cl0XmYPcXVpzoQ6Z69hTzMhjJ/AfrD4L0AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAAEAMAAA==eJxN03tMzWEcx3GhlIY0x9rCHymSrixz6/mdMko6nYacZBNCZWeTJZeiC85WrKUtxU7RVqOs1mlF0e95ntpchpYuWjHXahWzLm61hny/P0/b77/Xn+99vs/T1ZIbMNGyhowYU3lDVblsnSsp9lj+ht75tEzxS+/VbP7cmgB0d42W2Zf4N6LPZrgzo30jRcdVt9EgGxeGdv1xSr7npFV8v/YS2TXDTZJc10t1wlpwwEgloTYGqev0ayIJd4Ct4hj5zIzSxkdlAVNH/zsYPPa4njzPOCx11l5hat813SCFfURyiHTileAC4fKcMKI3/CWt66L4bXCEsHOFmeqf+CoNjuAIMLZdfvOcZu4/qjTkCHeCvxk+0ITS89I2aPgujD1b8rrpw9aTSkOwcAd4qaaOJl0IkxZCg6fwAnDY2HFaRGwlbAgEm4V3656xqzcdlQZ0nnChxyweCsSG6+AQcA9Yf8yBz4nZKYVCgw5sB/YGu8Ta89/2O5SGabeDzb1DzHRrldJQpPKUm5kVW/Uqm6hdNbGUbzhQSrAB7Q/Grc680/HkoVekGxrQKWDcqqn8EH+f8IX4QEMz+C14EzjrUTTP1vYSbFC7oHkd95lJCTZcA/uC8V6bM7+zvq5UpYGAPwlXd/jxg+aVMjZYwDPA2CbJcdzXGC1jA9oO3A5OdU3nXamJ8mZoSAF7n0uUcavYoFM8f0m8jA3oI2C83XCDjscPBsrYgNYLJ82z46NeVjI2oHuE9enOfMBcybAhHDwExjZNWSh/MvqRYc8i8FMw3u6PcwyPqBhnIdCADgdL4ASDgQ/YjTBsQA+C8XY9/Wt5veUpwwb0A+FRywirtTUxbEDXCEfkNzFHk4Zjg9pe45Ns6HUQx55p4z6R7nN5bNYejj3T3g4ejrLmWgc9xwa1pRfvmWnSk2OD2r+M+WxFyoDS8BO8UvhrfyyN2eqnNIyqbEzLp4tnxykN+8AaMP59p7RS2rA3jeugwVcY3/NYSzG1pCUrDb3CrWDPzov0hEanNKjdVuZDs0tsOTZ0qvwPtqZ15w==AQAAAACAAAAAAwAAaQIAAA==eJw9zOlLE2AcAGDpWEajwxwIZYeWll2M2Czb+2LqFlZajbTTss1SymAUnWSZ5Bwrln7QZaVJ5rbUyaLmkbw/E0dKjpomabhCDR2SbXlGKRHv70PPH/D4+f3XFLgmhP6OOEmnKrvp4YwLtLTTRKvtRnoorIAGtLXS7j8C2mUvpNML39M7YwmsTqGlzFVPW5amw6mOeGr6pqebPAwOxvSQ3o+B1OrxgmNGRMIrdHg6Zalk/24nnkvkWvLWNIGnMEtPjMkzeIozr5Ix5QCedlsUkYsq8bwrbJMNRkvx9BO9YU17buP5pXAR5CU04+k/sQEUNz14Bh8Tw06HF09VwEp4F/YJz0mRj13zleHZHpTN8i5uxPOBMxEE96V4bit6CJlXdHi6VjWA/nw5nu5RgAX5FjxvxVSBaosRz+aX2ZC2Q43n0eH50J81Tvjpi9bCpaEbhJ9z69ogRcgIP00nfsKP0wOEn4KRXzCSM0z46Tv+FcI1HYSfZJkZatJKCD+TF2+Fz+Z1eNbG5sITiYHxUyNrhYlHXYyf8mIvRJT8ZfxMD5oCQ+Js4Gdugxt26b8zfgr7KuDArBeMn0YQg6uaMH6mJMWDo0AG/IzLLoKqyXvAT6nsFfh/sAA/PYMN0Lm8Bs/GRhPY1j8GfvYVXwdr7Vng5/Y4AUTmTOMJDhvLMOfgqQ6dA3uTWvA00hXQODKMZ3pkKMgVo3h2qwOg9EwPnmqBm0nKnuLZ6zjHomI3Az+lwVLyzF+H55EQHVGmtuNpnldODIZxPCfDLCRfMo3n6o4iUr+vH8/XVhW5rHyOp2hoTLZWI8HzH4t9nnk=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0003.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0003.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.9999999712"         RangeMax="1.0000000298"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="856"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996978"        RangeMax="1.0000000359"         offset="1104"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BBE47A0" NumberOfComponents="3" format="appended" RangeMin="0.4999999856"         RangeMax="0.50000001489"        offset="2208"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3044"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3060"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3076"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3092"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3108"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3124"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3140"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3604"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAbwIAAA==eJw1zGtLk2EYAOBFKEt01DtBM7MPQ8uRhNpyWu/zIol5wEjnFG0eIqiVechKsRBtQQXGKLIypzG1RFiKlFFb7r5LM+2gUuIEsVK0+pKmYYUaGfczun7AJZP9V43DL/6IN4f3SBt+h0o1g5uYrccolRhfMlfdNtb76ZxUNmEWB4+oWF/gaenNKxMY+rzZo5Q0SbD54EFxSPRVBEhVI0k4OZEldnU3s4bMUsw+4AWWRPdpMKmherP7HDJpQR7mPnePRMCV4lP8XFAEwNknqfz81jXl7LVu5GdKYZEzJtF9LojPoWlvMD/XR8/BjafJ/KyakeGZMgM/c8eWIM6m5+cOcQxqlVp+Wm2N4Bzz5OcxcwiEnTTzUwhS4uLKIqOz3aDBsDV+/IyPjcPbR1X89NEwvJQbxE/NBxWaiuX8vCfMQ+Z0P6Mzqb4StFt1/GyS78RdahM/O+dz0FpmZXSmqUtwpqWd0fmg14jKpDZG5/LFBMxYucrodM4IaDOm89NruwXCD02KdHYWS/j546idzqjVAmweWeugMyu/Cr+0Khx0Os6XY02sl4PO1Bg9JkTN2eksjwjEiuoOO51/V++Cf4bWTmfhr0jsMZuATmk8B2t/WIHOdUIJeqg7gM7Q+0YU3rYBnQ9LE1BXcA3onB4VELz1QGd2oAUuKKacdLpWBPTf/5OfFREaHI70Qzotyjg8fEeFdL6WM7ReD0I6fR+rMLZRjnQOjH+HnJABfsbnVYJHkQ7orJt6Brdyg5HO6P5ZeD+RzM+vrTI8UW/g53LeEmwZ0vMz3eWChnAtP/flN0L3rCfS+Y6FwPHLZn7+A9IUeeM=AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAAKAMAAA==eJxN03tMjXEcx3HJLTqxjlxKnVOdqcQkyQ71POQyhNyWKGPL5D5GzDJSLt3MmS1tHNkYk0vJpcu5/L4uk7lM4VBkrjNFRkIZNZ/v09Oc/15/vvf9/H7Xa85bmipDpK2pO8k7Yr3dodcp/pxSb7+d6dJpSSvinp+NZq8eEyTcWhuj2JEhQWL3+s829rwgrcgLLbKzs3X19uSTLoL9zPjSOjR3iVz9tZd8EPZWbYr9a9UYd8i9v6yR7qt2gzU9XGzi/S7ZVm+3e6q2wvmtTdZNXmtlP6laBLZ1ehicWC+sHVlRcm3oKMpwcvPD7VbT/R9Sdu0Kmln9343LC8SZn7FKg7N91l0UY4vWyH3Q4AuHwxo4J6lUxP3eKFvQkAfPhS/DC9+dFPnbE5WGOar94aywTCHdClMaTLAMP4VXxo8QOzM+KA1JTtaa3el2t+HyQzQ4+5eXP8WNkmQPNHTZHS4kA81Jj5GvoaHLV+Hm2YOp4US40vAd/gjr4JSKFuHxqr/SkAz3h5/BC4yFYtkDi9KwCE5SbbNEkXFdncQN7EiY75MRmUCTvrZKfJMuc5uH/zLadLhdKkeDBt4ME2wcGEvnXzdIejRMgM/BvN1EUyClH7JK3DAB3gPzrYKXO8TRA1uUhiDYrPptbDyd+uYl1aCBfRrmnrvpqbS4KlRpYCfCfeHHXmk0sXi0dBMNT+DxML+fHgWrSL/YX2lg+6k2Vxhp5ncXpeE4PAXmtnGGZqGrPBvNDWyD6hWT48n1zSDBDc6+sTWVjtSNFNzALoD7wfvc0qi0KkxwA/sKXAGX566iioQA4YuGMrgE5u0yS4xUeaO74Ia9sE118pBmsbmqyJ6DhpVwGsw9aeYoKnTUKQ3OfqFNoPaUNqXnOdwB83bH2pPom6ZDlKHBDDfBVfDFllnkMb9RBKDhAjwI9oFdtwVS7Ser4PfDdsDc4xPtEOM7tghuYEeovrTBnVyDhxM3OPvRGz1NXyqRshE8Dea/Nj3bQDOKY+gOGqbCs+BK2M1nMBnuhZM3GvrCATDv9SelRWi7DSBuYHvCvJ2+Z6HY32ZRGnRwlup/+hOBWg==AQAAAACAAAAAAwAAYQIAAA==eJw9zOtLk2EYB2AThBU1dPpB0JVElI1maJhpvW+NwhMoHSeZqSMoO+gs0lgELgUTNT+opW4ms+GwViAeaKs9P8EDmaaia0qydUAroQNqkuAw47kHXX/A5ef3X+/4wB3h4bhDDFp5IlaNGgVr37xYmJcoTjW2C/0fvWKxWyqMXjQLg+HL4sgbf2QNVgs9aZOizHof54R0IURqEEucw/jkfn+o27FdbM5YQubxSmZM8Z1ZpU+ZXu47x0ptTKL0nQednaxa+5vORamB3bZN0PmjW8P6TU10puX/ciSk+M5FQYXWo210BsYX4MGrETpL5vQoKnbTmT2twzGri869Qgbqg210mqxysOlyOi/XWJjyupRO2dY6LHtv0vk8qwfKDQ10JqoG0HTJTOeWWOBedgudsR4zSrUVdLbJCpExm0RnqmGNHdjlFPjZKunGfoU/nR0LHpiKI+g8qVjAnFlJZ2f/PIJTI+lcLR+C2htIJ5urhTXvncDPTXvCEK3JpbND24svH87Y+Rm3/h2PnWV2fp7NXcdXS42dny/vrqBKVWnn54kEF5LjCuz8vBXTDJ0+ys7Pv+s7EKq22fiZ/6cLfTX+4OfhGQ/qlyLAz42yBQQoosDP3c/mIXsbCX523RjCqatB4OesqxbY7GL8zAwPQ5lUw/g55a1FaHoRnbqYHozva6DTGDyACy1mOoclgKmuhc6QF2aoHlXQOTSjxfmdyeBnYs4aCyhw0tn4+QgastvojH+dj0n3CJ3fLHpcM7jpXM3RYduYi87TU2o0R9voTMqVw/GznM4J0cKuVEjBz39K4JNqAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0004.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0004.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996879"        RangeMax="1.0000000277"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="856"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996449"        RangeMax="1.0000000371"         offset="1104"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BC01A08" NumberOfComponents="3" format="appended" RangeMin="0.4999999844"         RangeMax="0.50000001387"        offset="2216"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3068"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3084"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3100"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3116"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3132"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3148"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3164"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3628"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAcAIAAA==eJw10PtLk3EUgHEvZBfFpElWSmQaUYGTZWiy933ncFukTbRlVjpNnWs5Z1oWS1dLcwiKVE4sxBCRmDUXLCtm7JysrCCskFyEomYoXYjKS5QoxPdAzx/w+eHx8/ufFV8N2iDakCu0+8b5HmiBnZ0Vwqwnls+psUOBr1I4MeYPsT8aYP1svpD24TV4IorBWZcspA9vw+3lMVDavUJwWLLxueW296GhkVfoq9DPNwbNGfvJrIuYhRsv88g8qJ6Dw9NaMvsKJmF38wEyhyb64a5kF5mmmXoYO7TAM9PuCoZ33y+SWfktHJO/iMn8LIvBZ+9lZFrXxeLRNylkTqojsPqRhMxNq5fAPRpOZkBbH6RmjZCpKJJCToOWzImMPahPCyXzwlMldixHktn7RIVTg1FkpiclYVdLGJn3yzaic/gnz8y58VFQNjvJNOXpoN8/gUxRqhqVriGemfbNhXjs/EeemVOyIvS1T/HMXLiWiQOLb3lmWhrj0BPiIvNB9CKEGM1kHjlXC9c3BJC5NKBF8R0jmaOSM3jSc4nMfGMV/s6vJbNVU4jTZ0+RucUqRYdiH5nesJUYaF1L5uB0E6jcrRwzdVElOBOWyTHztLwGdfE6jpmZNgt2Z5dwzIwbMqCqVMMxM9gjR9HXeI6ZkbZg/GtbljKztOkqPJZeljIzPKgYe1RBwMy+P2YsThABM7v2VuPxXyKgny49LplWATNn5mWYIv/kZeZW+RqU+Lq8zKxKvgKJ4zu8zFyw52C3o4PMW2VlWD7iJNN804Sae71kSkJzcV7cSSanTES3oR6YGZUViItiAZgJyw1QVPGCzH9IloVOAQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAALgMAAA==eJxN0n9MzHEcx/GJuJXJj/mVkzGTH/0iv9qu7/cfM2aTU+M2Wc5VqxUndRd359cYWbFhKBk6G9n8WOviVr6ft59ZzB9+lGUjpC3JhLuFZrzeH9+2++/x53Ov93vL+RytyWVQzGm7aJ/jsrY3JZDKLje1alU7nkobl/3W/CvPSZ/bHyH6l5qlHYvHiuCxRhO7/tM4kfDyRRN7T3mUiJk9RmP7rZpwT7Oq99xVSgPsge/AFnezaOsrUB8mV5hy4Jdw5sIK06g0EsF8m3r6Spkw6D4LL8irFd6kFerPshG0SHc//Ld8vziSZVSf+FUaCLEjI1a86W5WImLzyB3iS8YIulK4UjaE2kujyRWdrmagoQZ2wynw9gORlL1zlVqNhuIQe2uC4tbUZNlQCfvhX3DGWxKOT5GyYRNcAj+Gt0WVCMfPOtmQDzt1B94k0ibnHPUuGn7Am2EB28xLaUj1fHUuGqzwMPgjtoqunU/tifPkJjFwG3wKvmgz0uW6CbIh1F5zQHQWfFa44QL8UfcJW7X40nhSiUTDKbgX5p7FeatpfUWYbEiBzXAznJ5uoeXPDbJh0J3w131rqODdUNnQC2+FeZ+wiiX0Or5b4QZ2u25XVhRtzGyQDW54g+7dWTdFfV2ubPDAt3TXu7Ip/+hVhRtCvc5hJ2O7T+GeQX+Au5/mUn/adYX36YH7YP6l63Gr6E9RlcL/M2jusfpiKNlvV1rQkAWbYO4Jf9ci7jsnyX0McBPMPZXxRdTcMVk2sJ/D/NtFDzzUsGy6wptsh2thvl1XTTGd3zZFNnTCN2BuO1y6joa3GmQDOwzmNs/BWJr4oDWVG3bBI3XnTmoVXwOHUrnBBg8L/nfZQDFFNiRo3MD+60vQ+Jfe+/bQguglGjewk+E4eHqpkzrcSRo3zIDjPEka3y4YtNDuDVM0bgjAFpjb4nfOoS7f99vcwO7X3Xj8lfiVeeY2N7DHb/zvUY8K6YTdLrgn1A9jd1D4N5eYjQb2nz6XGMBWnYl22txRJLiBnQlXwveOrKXungzBDewgzG0DpTOpbs0swQ2/4Wu6wxc9E9lHX2jcwDbDfLt/8+l2sg==AQAAAACAAAAAAwAAawIAAA==eJw90N9PzXEcx/GKWlazQ5ERq2aztZQdbWjf73dp1bkoRYoIlbSkX9Ri0rE4czTZYTqWFmZ1WK2c7Cg56fPqB6WxWC0H6zjZ0TmEUDqm1NjnfeH5Bzwunk5O/+t83usG/2yzVGM6IDXAC4G3JqUpo05MLvVGmmlKOmw+w9Z+d8fyqVEp5m0cjD5jrEnVLsUO3ca6gjqWozsn1StN6FMGsrZsDykqywEn0z5o4p+RqfIpRHX/OzJ3xhVht81CZktaGjZqBsgcGA1Ds7yRzHy7K8xJxWRq9RVseOKvyM3CL1qEjTeT+Sm8Dk9ed5FZtlSHvS+7yXwfV4VTjwxkrlxUCsOIlkyXqlBEJiSRGZXRwZLLLWSOxrciK0ZD5unHfbgxX0Pm3Z6nsPZeJzN280PUVl4mszWvGk1DR8n8aUlBtCaIzPz9Ntbu3EKmV+QLROu3kaldY0VKSTqZ1vAPMNUcJNNxZRDds9vJVFboYfQMJvOBfwk8c2dEbu454YJrK86SOddtQUjjV5GbI/JpHDE6k5ma68CvVBcyryZaYTv+Q+SmX1kH6qP6RW4y2XksKLtEZq/NEwrDMjIzfe2wywYFbhZFzCFzg03g5g71PHS77AI3gwfGocgZFrjpYeyB1+d7AjdXqSswo1YK3My5uARdwkKBm95uY2hQqBk3W37P4FBoJeNm7ZY/SJ+sZPRT/xFz+eWMm/bpLmyNyGDcDIi4ALkpgHGzOEyGTZaGDm46tG+gq18Nbt7Jm0DBqyBw8+TNb0i8vx7clC82YzrED9wUo9tgyHYFN30TVJgN6SQT8+7IOKZg3PwHOQ2lzg==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0005.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0005.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996805"        RangeMax="1.0000000382"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="816"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999997004"        RangeMax="1.0000000387"         offset="1064"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BC445A0" NumberOfComponents="3" format="appended" RangeMin="0.49999998403"        RangeMax="0.50000001912"        offset="2120"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2940"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2956"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2972"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2988"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3004"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3020"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3036"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3500"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAUgIAAA==eJw10t9rkmEUB3CRUGbOtFZEqwndGIHNlSmj+ZrIsM0sDEbsYhIUbkRhbFAmktHNss2bSHCxRiSruailDmpsPgcZ820sxlasSFpb2W9EB7XtQoWe58B7/oAPX77fIxIJdxNG7mghv2IwLy40cJ8n6uGottFcJx9I/ZJpICHRmV8oo8QirQFrpdbs/CaDPy+LxDZY5lpjx6ASGiGRoTi3/905WC1oSW+LkevZ6QXx0ilwa5Ro3vA44femCs09u2xwIS1DM35JB8r8OsfM6qwC5tU8mldyr0le3I9mz8nTZNinRLMu2gkLVTzHzNuhi1DfN8sxs3PDBQ/DwDHTFG6Gt5kYmtmSGmTeIJrbS6vkntOCZu5AF0n7eRMzr69dha96O5qH5T4Ym3agqYhfhqmIFc3nj87AljYtmp7QQZC2y9HMfiiScseMiZk7AtdI06gdzY69fpDkXiWZCScCMGeYTDLT9bQbbm3Ek8xc23oWouMPksx8oz4E8+cDSWYmlv+R73ePJJn595mfzDkmEkLOgt5OmNlAc05OO4iQk49YiZBT0aYlQs5t7XIi5JS6ZlJCTtuoPcXMfbTPpSoezV7ap75vFk037XM4DGg20T7fZ2JofqR9VnuDaKponwNOC2HmF9pnxs+jKaK7d2mUwEw/3T2/qQJm7qa7u9MyYOYY3b0mv46mnO6+qObR9NDdi+J+NLvp7k98SsLMx/Q/CysGND/R/zRqG9H8Qf9zXKJD8zj9z+ZKLTDzJ/3P1sEymiX6n/eH4mgu0/8MthjR/A/qV4JhAQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAABgMAAA==eJxN011IU3EYx3ExxDCxDBVHOsPZ5st8XelynrM0yELTMrPAmBWkptCLCSmh0Iy0XYTeaO9GlDXKFK2Lcuf/B73oQsIuhCBcTlOzUAyMlDDp9/w94u4+F+fAl//zPL6hg8rfsS4pabWBt7wbV+addcLVKb8Va7lG+O2TVaXQVpjlZRe5Et8UlWsU8i38O+usE/4XMqj4uLuED05k8+u9emtiVJ6UC9vhSHi2QOZnHumsu2cOsZ/wadgIV2xL5slNYdbjZjerhJPgYniLXyj3aH2slqAYHgBPwFkwL//GrtmH5LqGQs68LNXfZgkrtfI93QVho+ofDWX8ccWyHI0GcidsgKfLSrlmdFFOQsMUHAlT28mPh/jOfI98DA2l8A64AHZ+SOA980ymhudwHyzBfsGbuLW7TTRshi3wVXja8pQ9cKSLhin4oerihSu8XLor70IDuQKm95m+dJH3VbWLBm97ck5xk80hH0bDOGyGj8KxjRbubq0WDfHwKExt8UFbeYDLJBri4GCY2t5k9zOWMSFRQz88qPqzrZEv6UckaiBHGUakMW2elNJTz1NKhqU9aEiDfWEdHNlzjtcHDkjUEAHfhOmtWpr28zvmTokamuGXMLW5jaF8YalGogbynOrxufcsPDNcNJC3q6YGrWFEoQa1R3HDqWhILRlWqIEcC+vhiLUepVjtaYapjRo6zJ0KNVDbKzhL7fm1VKN49SjrPZrMcMWrR1mfF2bEPGgogi/DNLspzMhV1c706rz6YZrXV8xItjkYNZCz4ULYgBn9aa1m1ECegaktFjMKcZkYNZBjYJpdH2b0JWNCNJA/qf6OHX5Wscxoh2dgJ5wDT2KHdaOLooEcDdPsTmCH4/I9ooF2WwfTvF5gh1/PMyar+zwA0635Y4f3dbeJBv+1fRZttM8djnS2vs/3VR/Ajd/o1fPcjXvniRv3ztPRQD4LU1sVbtzYFMZpXufXbp8fgenGJ7U+nBoCYTdM7zOAG7fbh0SPC26EqWcvbjxtpVY0kE2q/wMe22AoAQAAAACAAAAAAwAAVAIAAA==eJw90t1Lk2EYBvAxYmM2zbKiIh3UgXogslhftPe1iPE6qYMdeOCBEiSrg2CRCSajoBNrupjhYKVYJGYt5r7EMfS5ZYzmwZvLGSaN/KhVmqwlBVu0DXueG97uP+DHxXXdMtn/m3lh80B6dZJPzPu5lbAXjteF+Sr1QbJRMgYBhY/3lR+Fc8oBOF8c5E1fbLAZsoAwZOWbXk5B0V4DrmEtf+TdGqxlPKTHGOI69v0B+WIczNUONG9bEvA914/mof2z0B6xoem/5oPydCeapckHENcIaF5PNUJarkaz48JbMtrtQLNqZB3mVQKa9+ybUN9rRPNKdgWeOhvQ5JyvYSFWi2Yy/wRKulRo7slfggFThGNmqmaDRKwCmre2svBZJ3LMPKb+C97oHMfMMv8PmHZFOWaOP1uAHc0ejpkWuxuULX0cM5NLFii0GtCsuJMjereoZ2br4QIoUqeCzJxp3AbxxJkgM9te/YK7WW2QmVs7l2BkojLIzDeacYhf3g4wM7B8E74+DAaY+dtTIOLF0wEpZ0YnEmZqac6p6ByRcs66okTKWdbsIVLOXS19RMqpbDMQKafgFqeZWUn7XFQJwMwe2qeu1wjMNNM+R50NwEw97fN9rBaY+YH2WdqlAmbupn0+MkXQ/ET7jFkFwkwZ3f1qtQNNK909netH8wDd3Ryxoemlu+9Nd6KpprsnNAKaFrr7T7kamHmD7j7W7UDzOf3PzOokmh/pf56sC6P5jf7nhMKH5ln6n4biIJrr9D+bhqxo5ul/Ph7WorlM//O+MYTmP8pEpd4=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0006.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0006.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996926"        RangeMax="1.0000000319"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="852"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999997242"        RangeMax="1.0000000298"         offset="1100"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BB81288" NumberOfComponents="3" format="appended" RangeMin="0.49999998463"        RangeMax="0.50000001593"        offset="2224"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3068"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3084"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3100"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3116"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3132"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3148"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3164"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3628"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAbAIAAA==eJw1zP1PzHEcAPBiIllyxbGalmKjqVtCtbuvc3S1K9dK2o260qPT9cixcpdEua0WPfDLjVq7TeM6h7OJvu+3pws/hLXdmcoRasMsnZj1MPZ5b15/wMvL6796/N2pwq7eK5zJ5eaulZXhUaeF8/RHcLVXyzHtTh93ZMwbtvln41R0N5fy9iVI5DuxT9PIpQ5vxJCMxTgTvYvrNWQhLhghp+qZJLFEh6t9CrEryYfOu39qUBUbSGdP/CnMmg6kM9Vagp7yZXROzkhRJPskYecG2XLc5OqRsFOXcBG2uDfTWRRSjAGr0nl2HpPpsUNUxLMzvcmAw1nFPDujhjRYXZrJs9OvX4Y7vop4dgY3+eHW8wsD7CxtaYMR8bkBds4/UmP8DS2wcyTmOFb0nwF2qrU6nMttAHZ2Zubj1IlKYGdovRhvJSYDO/mApehbvxLY+XSiBZS3L/HsFOxVosI6RGf7+nzMqx2nc1xagKOmj3TOtKejY/Y1nfrmKORXWOm0h82CQFtDp+pkA5jWLgJ2vkvbjpoUf2Sn/okcuxaCkZ2Wx0n42RGC7FTExaG5IwDZaS9bh7bhH3ROu0chudVCpzanCAa8Y+ms/BaE4i/RdE5Iw3HwjZTOOkEEHnq1m063Uoj6BzF0rvGdB/toELLz72U7yDOcdO4pEMNBo5rOOecYXEhT0Fkn9IDpeQ6dSuVPUE2o6byZ9wFiW/fR+eL9fbDFRNJZOtkI7gO/6Gyz+oHr+2k6Bx1NEKbJptMMHRDZXUXnfn0nHHZV0xk6ZQShJ5dOm7AQLGcT6AyrCAeteQmy86HhOn9P00znP4XIl4g=AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAAOAMAAA==eJxN039MzHEcx/FhaLXJr1nqMIZK+oGIuTtjNjWjH5IbES4WmnPprrrK79HWsfndD7+ymfwYO45Rvp83/SLmD3JMflRq0w+zpEtXW7zeH2fz3+PP594/9uV7C6+AUZrY6Fyyt40RIW/qFrJN80YLvxNlj9gXDnoK1/xYhe27tE8pj7ogna92KIWZL6X3mK4qBxZ0S6de3KKUWzwE2/tpKh03GLQV2YVa9kn4CVzjn0k/Oi3a/jlWNbsfroRbQg20ssGoLbiWJ9hR8Bm44mgctbfHa/vyhlMl3Ay74P6MqWSLma59/mCR9G23h899JSKP1Wk8/VNoGBzndl7/biJ7iIYb2DfgSrjJvpdm+0ZoBBrYLeMjNEHhVvWUDDM1ZIdpuGEyHJQTpjkHdzt1lLvOT8MNTlgH98LBWYHUYu9ScwO7x+2yE++EK7FIzQ3ssev/uiDYSPUN4wXPpxCugx/Dxqocql06WcxAA1uBm9HWXLKb7u7yE9zAroTPwnkZCeTn8BDcwB4Lc1vuYX/yqXIo3MAOgWthvY9DeDqPKNzAHgp7wXcsyZR27KZssMHpMLclmAykem8XX9AQD0+DV6Ct7eVWckXfkg3tcCd8Hr41czkNGAtlA/s3zG1J9okU+cAguIGthbltaGOtqDL7CG5gP4W5bW7KSlpjHUzcEAGvhgUct0pHy1570GI0/PMS+Nv+GNrZOIS4oQM2wMXwYGsE1Qe3yp5BcBP8C85K8qaNifdkgwVeC7/gWSXdF/dtW2VDDlzudtenUNKbA2XDT3gz/AjeEDufhhXPonA0/HMI7FM6iz6EBlERGtj1MO+uRK+i67ZxxA3/+3xst2jZ0SEbiuGvMLed0heL72WnZcP/LlV50rXUKFLQUALfhKvZNJKyfVeRCg2XYQvswu6Mh7xoS9ZyOZM0OBnmnqISp3g4YY5sKIDL4R444TMJc5sXcYMONsHcluqdLky9NtmwHTa7fXuTInImbaIaNNyAc+FnsC67Rrzt3EFONCTCDrgaHhFNonubXjZ4wD0w31JASqm4EhYpG8LhSzD//kD+QWFNUskGJ3wc5lsyxfuLz601ssECf3T7D0S1kRI=AQAAAACAAAAAAwAAZwIAAA==eJw9zP8v1HEcB3AsxlhDSVtK/NAP8m2yFvO5mUJDpxSzRGStLidiarNjysLSKHertWtpuZZG59JZ1Of99KVIbWosV/nyseSuqSS30xKmvV8/9PgDHnZ2/3X/1nxEY/NWmdaUJXuQP4czo4Eya5dOKL3zE8lPgmSnJy6yXesnMB+yXZb4SQ4h7ikeKRxlSSP34ZNSCVtIt9BcZkL3qjMyz8ULsacW4eU0g8b4KoGfHX+WkB6uFvh5L2IZaQtqgZ9J+q+wnq0R+Gmx9SA0Jlfgp3/MFeww+dNZEumOAOlhFD9P+ljg7jEs8rM4ZgXqULPIz0NVqxhJs4j8DB6aRVHee5Gfrl192P3NIPJzS1UtgqrLRH7mXfXAWNQ6kZ8rvRIiWn4wfo6F2VDQZQ9+ZikXsXzcAfzUHJnG/PlfjJ++FSIexw4yfjL3arhU1DN+vjS7Qd7uxfjpue8tEvQHwM+GbdPILs2h83P0F4xrT9BpaxhG/9+D4KeqVg/mFgx+Gv1K4alcojP9ggO0my/ROZncAUViHZ2qFwNoXNXS2dr3CjP9t+lM2NMJnfoancb8WzCMFNK5IGVgf10g+KnMNDPR3khn4XcNombb6DRHN2HgQw+d5Z46ZLzrpVOS34TqeTudm1xUMI5r6Fy7EY64lFQ69+aK7GiNROfy6DHUJ7+hs9y7CNrBSTrl8mKkmyU627KzEV43ROfrqUgYwlrozLM4QkotofO6vpaZ5tboHOh3gp9igk4dNmDn3QU6D6s2IsdkpdN33hne1ik6Dd4zrLXyGZ1+BU1MqbtMZ09ZAOtUuIKf/wAJ8rgIAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0007.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0007.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996358"        RangeMax="1.00000003"           offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="852"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996994"        RangeMax="1.0000000311"         offset="1100"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BBE47A0" NumberOfComponents="3" format="appended" RangeMin="0.49999998179"        RangeMax="0.50000001499"        offset="2200"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3036"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3052"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3068"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3084"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3100"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3116"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3132"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3596"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAbQIAAA==eJw1zNtLk2EYAPBVIGutgTOxzHYzXLqOTq1t9b1fkZUHOiwbteHxxibSNAuFVMwRURetIrJwTsyFSJodGBjpnqfU0kqtMLXEyqEXFWgSlY1FxvOOfn/ATyL57wzW+x9DbU6sGD4fL7K+GXg9kSGW2J6xL80SLKrLEssmnMJCbgBUQ2bx5XMHHB0dhboEvahsXY7peW7onAkTq4fT8S3TQOF5J6s/UorvgkqM3P+T0VmhS8bBxCh+uiNSML9Bzc8BKcOGqyp+RnaoUXRL+fli/BtYNf2MzrTcKlhsz+Sn/VcigtPBzx3j2XjpeyOjU6YsQYm2ndEZ32ZD+UALo9NbmooHiq4wOqdGlNghN/PTGuOCSoVfoPNesYiWwREDnVsXivBN/xIjnZa8akxwKYx0PqopR90WmZFOk9GMXepZA53luhiMK2030Pl34Rb83qM30HlTmoRGrQPovDuXjc1ljUCnSVuCXz13gM77PTZcmd4CdAbOpaI1eBno9E0r8YHtMNApW+8Cff6kj85wVQTOB3/wsy0rGTctikI6U3amoOuYGulclszwQo4K6Uz6oMazxVKk06OcA+tUHz/31lXBtrWZQOeM8AQ8u2KRTrlhFq53ZvCzclqC5WVZ/LSMBWB3q5mf64QxuBah56e71Q0wFoZ0Fjg1sPGEk5+mgzKoT9vOT5NDCzVrbPzscehh6YYKfm4e1sHF4pP8/KyIhtMPTfz86PX7ehtX8ZMdt/uMaU38nOz9I9S+Cp21g6vZ7e7Q6b8Rx7o/hc73BWrWG3OKnwVP5cy77xA/C4UhYYUimp+zExbB2xU6/wGrkXylAQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAAJgMAAA==eJxV0ntMzXEYx/GSECdRigl1dCZJEws7dvodQkUN+SO5X0Yhlw1HLJfkejTL/KHZ6jBMWgtnszmdX+f7MDrM/RKVTFaM47KQVjbh83z3sx3/vf587/k8RRFNrlVnfZVtll00PzpEHIytSGRPjokWezd8MrHXjo8WAZ2eGrZHCRGZjRdd0jlNrtr9voLdP2GD63lkhPT1x5XOz9Ux0vaNOvIbPcr8sK2X2dvP3kTSjEWKOfDLOoU9E+4Hp1oNlHwpyWxvcrmS4VT4NhwQPpj0dyeYo5RHQgdHwiPgPzntYqDPAPOL2Djy9kh/mzjU5VSs9Sv+8+5SE52qa1C4gV0CP4KbQrKoM6dL4R52F9wXtnUvobeBvxU3Gsrg9/ATuKp9NgVleJQINFyGdXA47L89ip58VBVu8IPr4Hp4RGKdiPu9VTZ4e+W0TPrZHCYb2B2ab2yz0NGGsbLB2wcC8snujleeouEgXA6rsKMomyqzRsqGa/AVeDhceNlI1Td6yIYDsB3mtjVDvokt7opEblgN52t+k5ZJVV9DBTe0wBdgvtWdAgutcscKbmBnw/3hp6H5lHJpnOAGdhJcC/uVZFPcAr3gBnYMzLcqcxhp1ndfwQ02eA78HE4wfBMR1RddR9EwETbA3KM6TWTKbZANTjgR5raCSVmU0tYpeK9CeDrsB+v0S8lyols29IN3wA7YOCiNKps/yAb2FXgYPOV4FB0qVmUDex/MbYbldeL84a2CG9jnNAeX6sjtM4q4IQSuhbmtI1RP8+IU8kfDDzgD7g2XkoHmFiTRVf4feA58HW5LH0yfTk8g3usr7IEj4ZWOdhH0Ooh4r2VwMMxtGUabWHbfKRvYSzW/XV4iyjvSZEOrZm4Ly60SCRXrKAAN3rYusYu5PzfRLTQc1uyE01vOipN5i2XDP+tha/x+Me1mvGwogqdqXpQ5RuwqfCd4L2+PnfxKHVq0UPZ44HD4ASxSf6mBxp3UBw0uLxf38K0RrXtkwxnNNXB3x2d1c+h62ZCtmbezNQrVx2qSDaaXQv1zxES8V9vDPPXYvR+yoeeDPLUY5vv8BYJ9kII=AQAAAACAAAAAAwAAXwIAAA==eJw9zN1LU3EcB2DblZmM1ITAF6SizNLS3jzWOSmVppC1izJHqLsxRdxMSrGE1GIsSQMlrTlHcXCUCpVNHLnfR9BF5ktlc5kyK9GLVShikcWwxe876PkDnoCA/wZMc6loyeuQQlYfS9KrUrxzj0plRenSV0sNSoxuqcKtFH35VYh+45JGXytw/sM5GBNtUmhXA7IKotC/qJeuO0cwKVlYsUEpmXJW8NHbhPDsK3ReS+rF+L5WOtvDHNCYZTrHAgFzs5nO8D4ZR9sNdI7M6KDefpLOzPw1ptA6RX5qfz0HGhV0ps7M4s5KDJ1BocsIiEugc2e3B8FjsXRay4dxuiSEznlXE/qCXSI/1ZERqFZq6HyqG0Du+FmBn4d83zExfEPgZ26BD4ltjQI/X9SuIulgvcBPVYoL9q1agZ+VSSbElicI/Pzr24bf6bZkfj4MtCIlTgF+PlmehaUiBvxUxS3jmxwPfj4b8mBzViz4+Uc/DLV3I/jJFprQUzTJ+Bm0OwLJmgLGz5DoZqx6L9PZfaEXe9a10nk8zYG2izKdGw4At/LMdO6flXFTZ6BTDi2Dej4D/MwwrrHDO5x0LoppkI910BksaNHaP0pn9UINKivcdOZOVeFEl4vOXWIO7obZ6GzvigKm9HQWNlpYwiUl+Kk6U89MmXY6VXWdrDbKQ+dQnY2tj/fSudfZwxp0P+j0KI3sqm2Czk9WDXM8uE+nVLpkT8ncQucXR7XY8tZ/toy3iZ2D/nPu3iNx8LP/nC6URUfkTzoLX94Wrafe01ksZoublEY6l9zTR6x2//kPX3mWLA==AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0008.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0008.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996993"        RangeMax="1.0000000262"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="860"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996815"        RangeMax="1.0000000305"         offset="1108"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BBCA6D8" NumberOfComponents="3" format="appended" RangeMin="0.49999998496"        RangeMax="0.50000001309"        offset="2196"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3044"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3060"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3076"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3092"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3108"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3124"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3140"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3604"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAcgIAAA==eJw1z/sv1XEcx/GTOJ0ZpgvHimXkuLQuNobx+XzlchjFOsuldTJJLpXTKY01MUlSa6RFs6hWOykOy8wpct7vVmfFKlJbLWujTpgoyyoyP7TP23r9AY+9njLZ/5Wjv4eJGRQK6U9rmpTspeCazETJ2K2UmlZ585qaQunDYhWfUvnxuuASqXLutVk57MofJR+Qnq2dhLb2L6xI4y9tmWRoO3GC+ei7efukDi2W7ZDXYkNmnnclJKZEL5v8BvTO5JNZEHIHYtTHyfx08Ao056STeViuhaBbXmRaLdPmsOgOMjNTBuBpXR8XprrcFe//diAzNCII5UN+yz/Hw3DIfSuZ5scq7PB3J9PauAitpm9cmOExVRBUUUKmKdoOG4OdyNRHxOH09T1cmOpGHW5sLuPCzHUrwuqks1yY53q0yC4e4cJ0HPPBBJtAMq9BJ/QbzUyYs5FyPDOxZBam7cN4zHFgIExDhh4XDmWBMO1minG+Ih+E+UObgYH63SBMtsEXTdkeIMwU5y743HLPLMyGV4OgqDWBMEMa1qOuWIHCHPQMw0sF3ijMkZ8cHS/7oTBLozZj9jYlChO7ZJgbbiUzfeoCfC0tBGEurouEJ4krUJgf62uhetcOMlf+aoO4slwylfs6IcqiI3P/mpvwUpVK5neXY3Bq1hOF+cJNBucLjWQOL9UzX4OCzNGIMZacsJNMj1g5f3735LJZas8bUk+TGXt0gc1pssi0POhlsS4BZDY5xLPxSBOZyk23+XzAKLVr8+Z481sVmXtVqyXn/jgy33e7SH+dksjsUculvjehZGYPD3CD1Z7MtKh0PvLuKpn/ADT9h50=AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAAHQMAAA==eJxN01lI1FEUx3HNEhcKM5RAW2ixbJ80SR3vf7IiUCdzyEZ7SMlqzMRWLRxyKQeLkAjMqKkU9EFJmQkTLf3fU9FCm5YLotHiVGZRjFpkiGXn3P4D/7fP45ffPXfLz7y2ptk65sw2Q6btpRzruUDYXLSU7/VtjSH33tTxU5Xroskdq5bzWT43ZXLIwn65bmAuJ7c01LZNOy8J9z0/HzP2fK2w76cMOX2zRmKL1kvB6DS0hDYXlMsBU01Sz/E+loMORL9CRxZUyy2pBdKmBzUxG9DN6ES0x4trsq0gV+psPMfdFXehpa7T8uEAveSXPBuiFM9Ef6lZLZ+t8pLaI1Lgu8rby+/ymZYA0ZCssmZsnH/uixUN5EF0Jzp1qQ+kn9khbcUGI3o3OgI9nDINmF+iaBhV3I7WPXvLS8ZXiIaNiqltLLuch+QPMmpQO6kwCAas9Ywa1A6siYP7w+8ZNZABTVtNBqVBXN0YC8cGl8PQB4xGeOvtZB3YkIV+j6at+j6GQZP9MaOG1+hG9Az0qN3JG7wsomEYbVNs79TAyJUlWmogu1n/m7WZIPLATi01SOhcdBfavKgQDOZDWuohz0Nr0RmxeeAZnKmlfciDQZnaV2hnix6eDW7QUgO5X/GR6d5QttJd24EN5Bw09TT8ngOR6dWcGm6go9A69Ik3esgf6ubU4HI3Gmp3g2P/Vx6NDXfRA+jV6NIHO6FM5+DU4DLtU34vAtZPkTk1kMPR4paKf/AvPWZODeRvirfpn/AL1/2BegwqX1zmAfH+ElBDhWJ6O32WH3inGWAVNsSjfdCb0fMzfOGPbzxQj9oVjiFeWhkK1HAJbUHTLU0stvJKd4doIFcpnqy1ykmP1oiGCZXz+5/Kxbv2iQYTugjdi+40vpOzqk+KhgHFGrTmQq98p/2YaAhFt6LpnucG3JKPnkoQDXNUjh85KFuZF1BDLPqq4ubGErbdbbFouI02oOm9NjnrWaunUTTo0BxNf83TxNkQzxYNXoqj0L8eNrOnRXuA7tll6rFZLrOLH5hosCumrWxlCWyr8a/YpF7lf/+IdBs=AQAAAACAAAAAAwAAaQIAAA==eJw9zvtL01EYgHFJWwZaYopCmaFl2ZWRzsrvOYiXhYoKgl3ISnKpWIYUdKOFSq4xxPIHN1YOJJmb84JRmqvOq+XIgaKtQk1GpUvH0GZe0lKJOO+g5w/48Hh5/a87OkxC9L5KumQaoVkRSpKd109bOjS0bkMDqa5eoCMrIuqKMpKa2FV6bz6DhdjUpCtrnPZuKYTm1gvkenYTPeBk4DM1L+wqjaWtTjdYLO2syFCBZlGkD6Tn9HpMuh1ezrjQLImLhGTpHJr2/EDQFYyiWSyys5j6J2g6LJfY0aSDaOblpMLbGgFNaZkamn5VoXlEeA6iIaPnc9IMQ9va0GSvGqEtug5Nh/Y2mDqL0YxPFkFMxSrhZmdSJWhjqwk3S4U+mH78iXBTqnVDuO4v4WZh6BIoM73RrDTbgaimCTf9v+khbd1Twk0NiMHaQtCcTVBA+dQdxk2fF1Yo8GOMm/pzP+H3xQnGzfUzy7Bc4WLcdOd+AXGpjXGTbDVAp0zHuJkTcBjGDXsYN9UDmeD7QALcjFM/gis3lMDNwR1mqCppAG6OzQH4PzQCN+WJzSA7pAFudj8rg8L4fODmKddG+C5fQHMlqIf1pJej+bl2Mygz3qDpvbgPjt91ohlyRgyJFjeaZwPDoT9qGM0fwbPs1mw9mn2hZez+tf3ATdtaMNmtV6L5VcgjWWkDaIalKMi7xkWPKVcR9Yk1NFMu3yTz2RNoWtqPkZRgE5p1flZhMkGCZsjOCLq89zyauUVXqe5DI5qno2pogLUPzeGOWvpn0yCaZqmCvn7fhabMlkr1DhWaJxNHydjHIDT/AcGooyI=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0009.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0009.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.9999999701"         RangeMax="1.0000000377"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="864"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996855"        RangeMax="1.0000000304"         offset="1112"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BC04C78" NumberOfComponents="3" format="appended" RangeMin="0.49999998505"        RangeMax="0.50000001885"        offset="2212"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3064"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3080"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3096"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3112"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3128"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3144"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="3160"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3624"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAdAIAAA==eJw1z+tLE1AYgHH1wzIvlbfsg4QtLzSWK8mpU9/TFMdUjFZzSCmaEaWJFCWooYguzUIy05qSRimRrTKTLJFzDhK6pER0w6GSOHTQzTQpmx+yOC/0/AE/eNzc/lfNI2LzQROthiX/UtL4eQPuGOyQa0khs5f2k4nLQUQlcULLfTXZNx1BZIPnkvrkSsJdIWSnqZdNbfiQ9R9rEDeu4N01bbCQagT7rvP8wM+aJK2uCU39uh/UzIUSYZbfS4fmtDw0k+UF4Dxcjqb5gx6+1xah+f5pGNgqYogwvXT9SS0dI2iqJ5ZpirEeTfU1I9P4BKO5zfWaDZh1aM7ljLMe3yI0NXHDbEyZg+ba1Vb2qFCGpm5SyqqaBtGU5FSzJW0Amt7+27lc1o3vDpOGTy8sgjBlfbnclr8JwjzbepRnGFZAmO2Fe7iXchDf777tZW+epaHp8beZtbV6UmFa7Xv5aqKJCrOu5DTvPGalwox3VHLu/EqFmThfwn+tfaTClM7E8bxhMxVmo3aMWSQJVJg3QrOZ6lA6E2aXc5VZ8x1MmFujI/mL4hAuzMouFa/siOLC1LcruD49jAtzeXELH0jdZML847rNei5cZ8LUlRvo7oZbaH7yXaFBsVIuzAdfwpm3/BSa7sp4VnbyCpqlyVHsSVUxmlMzEvbbI5YLU2Vvpi1aC5oPF93B5jKi2TDaBFHKQDQt6+9gcigTzbqsBbj5+AyaI35WiAnMRtPX0AVlykg0rXMHoSJwAM3qlFqgPZ5oDh3xJwXHTfiuCM4goxetTJjwqoDUe35jwmzMzCLPA+aZMOt3hJOXs2Z876b9cEKagOY/rzlqmw==AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAAJQMAAA==eJxN0m9MzVEcx3F/Qk1KkXJtbbXKn+HWDEW/c2rcaiSbalJWjNWajREx+TNJW/GE5pGwphD5l6Vwf+fUlIoo5aZbRJraakuWTZPh8z37td1nrwfnwXuf79k05Yv2N2YdK1h2XI7zMuvHXUnKQWEeouWZHyuEE4cSRPyvlRq5KdQiIuqe6PSmu6hNL61igtwzMBxuSd6uvKbam729tUg5oS6XFR23s4NJqTze8CE4X+tg0RVmzncu5IVwDKzBS178Y12VCfydXw5bbPg9fL5kGq+x7OBfw9zEpL/BKfn9bOVajS+4PFUmw2bYC048WMzcTdO4n3+cTIDnGm4djtCzi/+ohtcOnrBd0aPnxKoGp84rehTMYMt9qz7b/Si3oSEUdoVfw5+stbpH2gk+gIYRw91wpv2WrjWlqIY9cDhMbXHt6fphX2/VEAlnGT5bWC70VqvaJxeuNbxxzFkG5/moBrIZpq3OtQXKbeWhqmHSr+C43Utld0k4t6Nh0h/h32fmSZ+oANUwYZjaAuyvROFgH6OGQAefvDgunm1o0aghB34I0z4RzTHy3r8ARg2RcDVMW7WbsmT8y2jWhAbyVvgt7Jl4TLp5xrIeNJDnwLRP/YYkOVodwqjhBfzD8JbH8+XNvT81aiDfNhzMB8TplERBDSHwKZjaiv6ESaekCkENl+AZMG11zbxbjt5pE2/QcBUegzvh9bPS5Y3FNkEN5Osw3W56fIxcU/JUUIMTHArPhw/oLrLBclpQA7kW9odnn8kSX0t7VY+rg50r60VG1ypJPbMMU8+noBHhU7tDUkMf7A03w72WMdGwP1VSQzfcCNPtWns6xM2qSEkNbYapzXr3olgYMkNSw3PYBFPbg8cF2kDmhGq4Bw/C6i9l92plXptVQwFcCtPt2itmsrD+I5L+jM0w3Wv1JRfWsjxHdqHBbLgP/lD8XcvTk1WDzcFudaWaW8YC1eDq4H7fRyytpko1OLrM0503NnuqBnITTG183Qpufxoi6V7kLrgd7hwL5qsurJaf0TDpfmozmXiZyVfSfw42TD3VQx0sf59d3avGwf8B8pU1oA==AQAAAACAAAAAAwAAbQIAAA==eJw9z/8v1HEcwPFLpiKNQ+mX1tTaOrc06g7zeS2MTk3bddJWlGqtWYq+bc7mVqrDypTuIqPCIeSkjei8X2YWQ6Zzl8P1xbfbpLKy6KxZ7f36oecf8NieItH/OnfIJ4TY4C5hRrwIBV/U8DDxKCT3dsP4lUYYuqqHcLezoHvSBTtHakDSPhvRLG2FTmcZbCwJwuHlu7D08zKEDjahIWczTMS4gs3/K+7+5SIolF7AzYSl+0KO/SmZ6rJ+oSjuM5lR0inBsW+ZzIa3VmH+5hyZA88NgjWrhUx3ZYigK48hM3LoAou+tYbMyDxXjF1fTOYGpxxbG8xk2pPisc5zjszY0Ejsk30gc+G2H9ak1pOpNFcyzb0wMt2SRDijeEDvHuJClEq2kzlZ0oMjE2fIlDR/RGuKhsxz+nd4MDGdzNLUCnSXhZFZ3B2EbY19Ajdd/orxkT6vg5sWWxX+iPBn3NRenMbHh1WMm2GTK9jpOM+4GfFpHhcXkhk3A8ba8GRXIONmgSIOe91MHdy8s3WUhe/pZ9yscmSgJeUUcnNdcC2+SCtDbmZXvcbsciNyM6G0CRMOGJCb36dzsTVGg9xccfpgXYY7clOpHunYku+N3Jz1TGd+8koyK+aqmYd0ksxVsnaWefwPmdeijKxe843M4TEt++3yisxwm5jpFPvJrJy+IVidrmTm93jBLpmOzN4lBZhNg2Rqj6RA4TMHmW+8VbDXd5RMz8RtkCmrJdNibxayfGVkXo9eDawuj95Nh4rgtMqfzKBNA9BzSUUmtExB7to0Mgvi34PR5wSZuV7V8HI8kEwDC4FjASbGzX84coAmAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>

--- a/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0010.vtp
+++ b/Data/PVD/paraview/singleSphereAnimation/singleSphereAnimation_source93T0010.vtp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="64"                   NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="104"                 >
+      <PointData Normals="Normals">
+        <DataArray type="Float32" Name="Normals" NumberOfComponents="3" format="appended" RangeMin="0.99999996952"        RangeMax="1.0000000308"         offset="0"                   />
+      </PointData>
+      <CellData Normals="cellNormals">
+        <DataArray type="Int32" Name="vtkOriginalCellIds" format="appended" RangeMin="0"                    RangeMax="103"                  offset="816"                 />
+        <DataArray type="Float32" Name="cellNormals" NumberOfComponents="3" format="appended" RangeMin="0.99999996232"        RangeMax="1.0000000324"         offset="1064"                />
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Array 0BC01A08" NumberOfComponents="3" format="appended" RangeMin="0.49999998476"        RangeMax="0.50000001541"        offset="2052"                />
+      </Points>
+      <Verts>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2860"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2876"                />
+      </Verts>
+      <Lines>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2892"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2908"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2924"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="2940"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int32" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="2956"                />
+        <DataArray type="Int32" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="3420"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAAAAAwAAUAIAAA==eJw10t1LU3EYB3DLXqC9aN7UlubLTC/S3Bxd5A7nd9dwbkYSpV2MTMuLILpStxzzQrro2IrSm6Ybyggqo7kDhpzj+YVOVjjUGWTKCgoXRV1k5ugFWb/ngfP8AR++PN9vXp56/TTxM8B9jYZP7c36iWtngz+9lLN92+4k44ccpHyunTMeKSEdBi+pjglcfKONbyr2kNeVAnev5Zry46ydnHni5vaPlNF4Ns0b32Vto9+v0pe37NxiysmBOboU5re0ER7M8gM68i9RSMAsFk4Qf42VgOldryW1PfUEzLdGDRlc0BMw504+5AtcIR7MiVjp9HY2gObhFb+Uy8+gGZr/KAklDjRjokYWy7xotlRp5CGTB834xAcpfsGO5pv1bqlhJ41mUVGT7G5uRPP8o3FF4MbQ9AkF1OLUo7kSsdBnBjOauk0z7e2qQ/PKAx292apFM39rRPk8HETz4u+AXBFLRcG07csoyV/VIpgDpQ7a0TAkgmkyeenAjRcimLurPPTT1JQI5lSbna5Z7otgXs6llfcHK0QwC1nOS82NMpjnWM473JgCZh/LaXXqKZjLLOdzg5mCqWE5vV11FMxOltPXqqVg7mI5vwwHFTDXJ/GfaL5a9kt5ezJodsfxn2j+jeE/0Qwew3+iGX6K/0Tz7hr+E81Z1nsy5UQzzHrf1EbQNLHe/yQK0TzKevfVWNHsY70f76lHc5X1fntBj+Y8613nCqEJ++yPhqfVfYYWc5K6z8HZdlndZ3JSkNV9Xq8UZHWfM4/dsrrP3tWsBOZ/jyJwWw==AQAAAACAAACgAQAAqAAAAA==eJwNw4c2QgEAANBH2WSPSGZlJXtnC8mWPTLS//9B955zgyAIaqw1ZNg6622w0SabbbHVNiO222GnXXbbY6999jtg1EGHjDls3BFHHXPcCSdNmDTllNPOOOucaefNuOCiSy674qprrrvhpltuu2PWXffc98BDjzz2xJynnnlu3gsLXnrltTfeeue9DxZ99MlnX3z1zXc//PTLkt/++OufZf+tWAVzVRTtAQAAAACAAADgBAAA0gIAAA==eJxN009I02Ecx/FDYmIEJoPUXFn2V6lbBtWeX5QEdihImfNfzLUstalrkKaITc2iXJaHtCI62EGqmRtoTdrzQ3ew3JSVF0MvHlbQFOyQBl76fJ89P/jdXoef8maf5zuebGUlw5Mmx+sWNbI0ZvrTZmNkdzAYXFiyCg+OVPO/cwHxzQC8ORcIktvwzY8lKyd/x9+utdmEP+F/XhqeFN/kpjnZA1vUZGxqVvbpnLu6S9k608O+3VOEU6TL35cqC40T7FpRmGmugSs365QvOWH2pCDps+an8ECGWYmmB1jv9nmu9+BMhnLe0M08HWdVva/4QqYTYy5GDVadQ4fbWcaQUaGGKXin9E/DB7Y7tVyhnl/wHtgOD05yVtHnUHxoeAZXwhVwzqyXrTotyiM07IVXYA88taOF8eYspRcNIWnqaciPBD3rTtHQBPdKb0vr5kc7s0VDKnwMjsK1b8f53VaLaCB3SP9Omubri/WiIS6twE0lY/xkzCwa9L58w82HKjNFT7HOZxZucfPatNiIXCadbzCqd4rdYqM8+LZ0Q2GZal/2M2ogX4et8L+PN9UDsSlWhAbN2bDXW6p29fvYYzSMwJ0w7eWLZ6rvXO2MGkZhL0y/j4KGyrXpIDWQq6SPoKG12M21Hs0ONNQu+3k1GvTeQEN+bIpTAzkPviB7evp9nBrI92Hajhr8rnbukT2j0nWJvTg16J2c2EilhhSd7djI3WpRbWi4Kk2/VQwbbSzWq7SRZtquDhudjpnVh2ioh0/BtNfFxEYqNZDfSNfgDR8fc4kGO1wgHUm8YdEwq3M88Z5FwwpshOm+XuENl/c5RMPLxNtW/fAhvOG40yIaDur8FW842JwlGmYT71ml7fbjxjttUbERuUszbnzLTI/YiJwkXYEbn2+c4HRfelfhxkM5YU73rlm790h6gPfRjcNhmLZ7gRs/Z+jm1PAcLpT+D3k9U84=AQAAAACAAAAAAwAASwIAAA==eJw90t1LU3EYB3DLXqDpqhHUXtqaW3aRXUhU5Dn9LrvJGUqUxZBKh3fR1RRzrAvporPNQXlVcyFRVNrOzgGpnfkrdHLaC74F2QYJhkhhF5k52kLW73ng9PwBH748329V1f97p/7S899F29mdxQpxbXWR87N+bm1zhYwczBD71DJnMkdIp7FMjkk6PrWSP3fBUiJpp44Pt61N/GxVycWXS9zux09oqugmps9eLvJjlb6/p3Iz8zkOzMisjWzUOAmY9j1B8lcNEzAtwmvib5AJmH2FMXKiRyJgfjIJJJANETCnTpnIXpeVgDkqRd9sFvU8mIcWKolKtQfN4ekbinA4g6YkC4p8pIxmW72gPHSU0EyNdiipKyqaHwvFRNOWG02DIat0tKQx5+VndVTg7Wj6hEHa2BxCc+FpnI4ZRTRr10Xa2x1D0/MgSO+0B9Cs3rDQ1SEzmtf+6JN1UqsIJrfLQ3O/n0tgDtgytLPpgAymw1GmA7fPyGBury/Rr+OnZTDHr6o032iQwbxZcdMv+0ckMPexnNdb0gqYl1jOIG+nYPaznCebQxTMOZYzZhQpmDqWs687RsHsYjl97QEK5jaW89uQmYJZiOM/k2B+mKskqnZ40PSm8J9oliX8J5qPjuI/0Yy+wn+iOZjHf6I5yXrPzecwZ5T1vl7jRNPBei+pYTStrHdfg4xmP+v9eI+E5iLr/X42hOY0673WZUUT9nlXtL3V9jk841e0fQYmlxVtn7m4Lqnt85ZTl9T2OfFiSdH22bvoVcD8B4iYm9A=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAQAAAACAAADgBAAASgEAAA==eJwtz9dSAlEQAFEjKkEkKVGSEiUpSSX8/1+5U55bNTVd0w+9e3fx/x5NvIqJ1zTx+ibexMRbmXh7E++czGUyV8k84Nj3btfJpHGai9tNMhmc4eJ2m0wWZ7m4pZLJ4RwXtzv/lLJz2tF5wrHzbtEp4AKX1iniIpfRKeESl9Up4zKX8w0VXOHyOi849rNbdKq4yhV0arjGFXXquM6VdBq4wZV9QxM3uWedVxy75RadNm5zVZ0O7nA1nS7ucnWdHu5xDd/Qx32upfOOY7+5RWeAB1xbZ4iHXEdnhEdcV2eMx1zPN0zwhHvT+cCxp27RmeEZN9CZ4zk31FngBTfSWeIlN/YNK7zipjpfOPanW3TWeM3NdDZ4w811tnjLLXR2eMctfcMe77lPnR8c+9stOr/4l1vrHPCB2+gc8ZHb6pzwidv5hjM+c3/XfSYxAQAAAACAAACgAQAAxQAAAA==eJwNwwFEA0AAAMCvlFJKKZtSSillsyxLETFGRERERETEiIiIiIgRMSIiIiIiIiIiIiIiIkZERERExLrjykIIFVZZY50NNhm1xTY77LLHPuP2O+Cgw444atqMY4474aRTTjvjrHPOu+CiWZdcdsVV11x3w023zLntjnl33XPfAw898tgTTz3z3AsvvfLaG2+9894HH33y2RcLvvrmux9++uW3P/76Z9HSkhDKrbTaWuttNGKzrbbbabe9xkyYNOWQ/2GFLRA=
+  </AppendedData>
+</VTKFile>


### PR DESCRIPTION
This PR adds the pvd and related files from paraview data files.  The paraview license is included.  There is one additional file not from the paraview data files, but it is explicitly commented as such. This file was added since `timestep` and `group` are not always included in pvd files.

This will be utilized by https://github.com/pyvista/pyvista/pull/1564.

The additional pvd file was tested in paraview without error:
![image](https://user-images.githubusercontent.com/39341281/131355581-72dac2ed-60db-43d6-a3c9-c71ed861ac33.png)

